### PR TITLE
Only show big blog post on page 1

### DIFF
--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -61,21 +61,21 @@
               href="{{ content.absolute_url }}"></a>
           <div class="blog-index__post-content  blog-index__post-content--large">
             <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
-              {{ content.post_list_content }}
-            </div>
+            {{ content.post_list_content }}
           </div>
-        {% else %}
-          <div class="blog-index__post blog-index__post--small">
-            <a class="blog-index__post-image blog-index__post-image--small"
-              style="background-image: url('{{ content.featured_image }}');"
-              href="{{ content.absolute_url }}"></a>
-            <div class="blog-index__post-content  blog-index__post-content--small">
-              <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
-              {{ content.post_list_content|truncatehtml(100) }}
-            </div>
+        </div>
+      {% else %}
+        <div class="blog-index__post blog-index__post--small">
+          <a class="blog-index__post-image blog-index__post-image--small"
+            style="background-image: url('{{ content.featured_image }}');"
+            href="{{ content.absolute_url }}"></a>
+          <div class="blog-index__post-content  blog-index__post-content--small">
+            <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
+            {{ content.post_list_content|truncatehtml(100) }}
           </div>
-        {% endif %}
-      {% endfor %}
+        </div>
+      {% endif %}
+    {% endfor %}
   </div>
   <div class="blog-pagination">
     {% set page_list = [-2, -1, 0, 1, 2] %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -53,17 +53,29 @@
 <div class="content-wrapper">
   <div class="blog-index">
     {% for content in contents %}
-      <div class="blog-index__post {{ loop.first ? "blog-index__post--large" : "blog-index__post--small"  }}">
-        <a class="blog-index__post-image {{ loop.first ? "blog-index__post-image--large" : "blog-index__post-image--small"  }}"
-           style="background-image: url('{{ content.featured_image }}');"
-           href="{{ content.absolute_url }}"></a>
-        <div class="blog-index__post-content {{ loop.first ? "blog-index__post-content--large" : "blog-index__post-content--small"  }}">
-          <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
-          {{ loop.first ? content.post_list_content : content.post_list_content|truncatehtml(100) }}
-          {# <a href="{{ content.absolute_url }}">Read More</a> #}
-        </div>
-      </div>
-    {% endfor %}
+      {# On the blog homepage the first post will be featured above older posts #}
+      {% if (loop.first && current_page_num == 1) %}
+        <div class="blog-index__post blog-index__post--large">
+          <a class="blog-index__post-image blog-index__post-image--large"
+              style="background-image: url('{{ content.featured_image }}');"
+              href="{{ content.absolute_url }}"></a>
+          <div class="blog-index__post-content  blog-index__post-content--large">
+            <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
+              {{ content.post_list_content }}
+            </div>
+          </div>
+        {% else %}
+          <div class="blog-index__post blog-index__post--small">
+            <a class="blog-index__post-image blog-index__post-image--small"
+              style="background-image: url('{{ content.featured_image }}');"
+              href="{{ content.absolute_url }}"></a>
+            <div class="blog-index__post-content  blog-index__post-content--small">
+              <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
+              {{ content.post_list_content|truncatehtml(100) }}
+            </div>
+          </div>
+        {% endif %}
+      {% endfor %}
   </div>
   <div class="blog-pagination">
     {% set page_list = [-2, -1, 0, 1, 2] %}


### PR DESCRIPTION
This PR updates the blog template so that the large "featured blog post" is only displayed on the first page of the listing. Pages 2 and beyond just show a grid.