### PR TITLE
Add fallback images for blog featured images

### DIFF
--- a/src/css/_blog.css
+++ b/src/css/_blog.css
@@ -57,6 +57,7 @@
   background-position: center center;
   background-repeat: no-repeat;
   padding-bottom: 63%;
+  background-image: url('{{ blog_default_featured_image }}');
 }
 @media screen and (min-width: 768px) {
   .blog-index__post-image--large {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -37,6 +37,8 @@
 {% set page_accent_bg_color = '#F8FAFC' %}
 {% set page_logo_max_width = '200px' %}
 
+{% set blog_default_featured_image = "https://cdn2.hubspot.net/hubfs/6326501/boilerplate/grayscale-mountain.png" %}
+
 {% include './_reset.css' %}
 {% include './_normalize.css' %}
 {% include './_dnd_areas.css' %}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -37,7 +37,7 @@
 {% set page_accent_bg_color = '#F8FAFC' %}
 {% set page_logo_max_width = '200px' %}
 
-{% set blog_default_featured_image = "https://cdn2.hubspot.net/hubfs/6326501/boilerplate/grayscale-mountain.png" %}
+{% set blog_default_featured_image = 'https://cdn2.hubspot.net/hubfs/6326501/boilerplate/grayscale-mountain.png' %}
 
 {% include './_reset.css' %}
 {% include './_normalize.css' %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -57,7 +57,7 @@
       {% if (loop.first && current_page_num == 1) %}
         <div class="blog-index__post blog-index__post--large">
           <a class="blog-index__post-image blog-index__post-image--large"
-              style="background-image: url('{{ content.featured_image }}');"
+              style="background-image: url('{{ content.featured_image || blog_default_featured_image }}');"
               href="{{ content.absolute_url }}"></a>
           <div class="blog-index__post-content  blog-index__post-content--large">
             <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
@@ -67,7 +67,7 @@
       {% else %}
         <div class="blog-index__post blog-index__post--small">
           <a class="blog-index__post-image blog-index__post-image--small"
-            style="background-image: url('{{ content.featured_image }}');"
+            style="background-image: url('{{ content.featured_image || blog_default_featured_image }}');"
             href="{{ content.absolute_url }}"></a>
           <div class="blog-index__post-content  blog-index__post-content--small">
             <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -57,8 +57,10 @@
       {% if (loop.first && current_page_num == 1) %}
         <div class="blog-index__post blog-index__post--large">
           <a class="blog-index__post-image blog-index__post-image--large"
-              style="background-image: url('{{ content.featured_image || blog_default_featured_image }}');"
-              href="{{ content.absolute_url }}"></a>
+            {% if content.featured_image %}
+              style="background-image: url('{{ content.featured_image }}')";
+            {% endif %}
+            href="{{ content.absolute_url }}"></a>
           <div class="blog-index__post-content  blog-index__post-content--large">
             <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>
             {{ content.post_list_content }}
@@ -67,7 +69,9 @@
       {% else %}
         <div class="blog-index__post blog-index__post--small">
           <a class="blog-index__post-image blog-index__post-image--small"
-            style="background-image: url('{{ content.featured_image || blog_default_featured_image }}');"
+            {% if content.featured_image %}
+              style="background-image: url('{{ content.featured_image }}')";
+            {% endif %}
             href="{{ content.absolute_url }}"></a>
           <div class="blog-index__post-content  blog-index__post-content--small">
             <h2><a href="{{ content.absolute_url }}">{{ content.name }}</a></h2>


### PR DESCRIPTION
Currently, when a featured image isn't set there is a big empty space left. In and effort to encourage featured image use, this PR sets a fallback image that will display when no featured image is set.

![image](https://user-images.githubusercontent.com/9009552/63976412-4479c880-ca7f-11e9-8bae-3a720f23738f.png)
