### PR TITLE
Fix blog pagination alignment

### DIFF
--- a/src/css/_blog.css
+++ b/src/css/_blog.css
@@ -149,13 +149,14 @@
   pointer-events: none;
   cursor: default;
 }
+.blog-pagination__prev-link svg,
+.blog-pagination__next-link svg {
+  fill: {{ body_color }};
+  margin: 0 5px;
+}
 .blog-pagination__prev-link--disabled svg,
 .blog-pagination__next-link--disabled svg {
   fill: #B0C1D4;
-}
-.blog-pagination svg {
-  fill: {{ body_color }};
-  margin: 0 5px;
 }
 .blog-pagination__number-link:hover,
 .blog-pagination__number-link:focus {

--- a/src/css/_blog.css
+++ b/src/css/_blog.css
@@ -106,52 +106,59 @@
 }
 
 .blog-pagination {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   text-align: center;
   font-family: {{ secondary_font_family }};
   margin-bottom: 3.3rem;
 }
-.blog-pagination > div {
-  display: inline-block;
-}
-.blog-pagination a {
-  display: inline-block;
+.blog-pagination__link {
+  display: inline-flex;
   padding: .25rem .4rem;
+  margin: 0 .1rem;
   color: {{ body_color }};
   text-decoration: none;
   border: 2px solid transparent;
   line-height: 1;
   border-radius: 7px;
 }
-.blog-pagination svg {
-  fill: {{ body_color }};
-  margin: 0 5px;
+.blog-pagination__link--active {
+  border: 2px solid #B0C1D4;
 }
-.blog-pagination__left-arrow {
+.blog-pagination__link:hover,
+.blog-pagination__link:focus {
+  text-decoration: none;
+}
+.blog-pagination__prev-link,
+.blog-pagination__next-link {
+  display: inline-flex;
+  align-items: center;
+}
+.blog-pagination__prev-link {
   text-align: right;
+  margin-right: .25rem;
 }
-.blog-pagination__right-arrow {
+.blog-pagination__next-link {
   text-align: left;
+  margin-left: .25rem;
 }
-.blog-pagination__left-arrow--disabled a,
-.blog-pagination__right-arrow--disabled a {
+.blog-pagination__prev-link--disabled,
+.blog-pagination__next-link--disabled {
   color: #B0C1D4;
   pointer-events: none;
   cursor: default;
 }
-.blog-pagination__left-arrow--disabled svg,
-.blog-pagination__right-arrow--disabled svg {
+.blog-pagination__prev-link--disabled svg,
+.blog-pagination__next-link--disabled svg {
   fill: #B0C1D4;
 }
-.blog-pagination a:hover,
-.blog-pagination a:focus {
-  text-decoration: none;
+.blog-pagination svg {
+  fill: {{ body_color }};
+  margin: 0 5px;
 }
-.blog-pagination__center a:hover,
-.blog-pagination__center a:focus {
-  border: 2px solid #B0C1D4;
-}
-.blog-pagination a.active {
+.blog-pagination__number-link:hover,
+.blog-pagination__number-link:focus {
   border: 2px solid #B0C1D4;
 }
 

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -81,14 +81,14 @@
       {% endif %}
     {% endfor %}
   </div>
-  <div class="blog-pagination">
-    {% set page_list = [-2, -1, 0, 1, 2] %}
-    {% if contents.total_page_count - current_page_num == 1 %}{% set offset = -1 %}
-    {% elif contents.total_page_count - current_page_num == 0 %}{% set offset = -2 %}
-    {% elif current_page_num == 2 %}{% set offset = 1 %}
-    {% elif current_page_num == 1 %}{% set offset = 2 %}
-    {% else %}{% set offset = 0 %}{% endif %}
-
+  {% if contents.total_page_count > 1 %}
+    <div class="blog-pagination">
+      {% set page_list = [-2, -1, 0, 1, 2] %}
+      {% if contents.total_page_count - current_page_num == 1 %}{% set offset = -1 %}
+      {% elif contents.total_page_count - current_page_num == 0 %}{% set offset = -2 %}
+      {% elif current_page_num == 2 %}{% set offset = 1 %}
+      {% elif current_page_num == 1 %}{% set offset = 2 %}
+      {% else %}{% set offset = 0 %}{% endif %}
 
       <a class="blog-pagination__link blog-pagination__prev-link {{ "blog-pagination__prev-link--disabled" if !last_page_num }}" href="{{ blog_page_link(last_page_num) }}">
         {% icon name="chevron-left" style="SOLID", width="13", no_wrapper=True %}
@@ -100,12 +100,11 @@
           <a class="blog-pagination__link blog-pagination__number-link {{ "blog-pagination__link--active" if this_page == current_page_num }}" href="{{ blog_page_link(this_page) }}">{{ this_page }}</a>
         {% endif %}
       {% endfor %}
-
       <a class="blog-pagination__link blog-pagination__next-link {{ "blog-pagination__next-link--disabled" if !next_page_num }}" href="{{ blog_page_link(current_page_num + 1) }}">
         Next
         {% icon name="chevron-right" style="SOLID", width="13", no_wrapper=True %}
       </a>
-
-  </div>
+    </div>
+  {% endif %}
 </div>
 {% endblock body %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -89,26 +89,23 @@
     {% elif current_page_num == 1 %}{% set offset = 2 %}
     {% else %}{% set offset = 0 %}{% endif %}
 
-    <div class="blog-pagination__left-arrow {{ "blog-pagination__right-arrow--disabled" if !last_page_num }}">
-      <a class="blog-pagination__prev-link" href="{{ blog_page_link(last_page_num) }}">
+
+      <a class="blog-pagination__link blog-pagination__prev-link {{ "blog-pagination__prev-link--disabled" if !last_page_num }}" href="{{ blog_page_link(last_page_num) }}">
         {% icon name="chevron-left" style="SOLID", width="13", no_wrapper=True %}
         Prev
       </a>
-    </div>
-    <div class="blog-pagination__center">
       {% for page in page_list %}
         {% set this_page = current_page_num + page + offset %}
         {% if this_page > 0 and this_page <= contents.total_page_count %}
-          <a {% if this_page == current_page_num %}class="active"{% endif %} href="{{ blog_page_link(this_page) }}">{{ this_page }}</a>
+          <a class="blog-pagination__link blog-pagination__number-link {{ "blog-pagination__link--active" if this_page == current_page_num }}" href="{{ blog_page_link(this_page) }}">{{ this_page }}</a>
         {% endif %}
       {% endfor %}
-    </div>
-    <div class="blog-pagination__right-arrow {{ "blog-pagination__right-arrow--disabled" if !next_page_num }}">
-      <a class="blog-pagination__next-link" href="{{ blog_page_link(current_page_num + 1) }}">
-      Next
-      {% icon name="chevron-right" style="SOLID", width="13", no_wrapper=True %}
+
+      <a class="blog-pagination__link blog-pagination__next-link {{ "blog-pagination__next-link--disabled" if !next_page_num }}" href="{{ blog_page_link(current_page_num + 1) }}">
+        Next
+        {% icon name="chevron-right" style="SOLID", width="13", no_wrapper=True %}
       </a>
-    </div>
+
   </div>
 </div>
 {% endblock body %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -91,7 +91,7 @@
 
     <div class="blog-pagination__left-arrow {{ "blog-pagination__right-arrow--disabled" if !last_page_num }}">
       <a class="prev-link" href="{{ blog_page_link(last_page_num) }}">
-        {% icon name="chevron-left" style="SOLID" width="13" %}
+        {% icon name="chevron-left" style="SOLID", width="13", no_wrapper=True %}
         Prev
       </a>
     </div>
@@ -106,7 +106,7 @@
     <div class="blog-pagination__right-arrow {{ "blog-pagination__right-arrow--disabled" if !next_page_num }}">
       <a class="next-link" href="{{ blog_page_link(current_page_num + 1) }}">
       Next
-      {% icon name="chevron-right" style="SOLID" width="13" %}
+      {% icon name="chevron-right" style="SOLID", width="13", no_wrapper=True %}
       </a>
     </div>
   </div>

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -90,7 +90,7 @@
     {% else %}{% set offset = 0 %}{% endif %}
 
     <div class="blog-pagination__left-arrow {{ "blog-pagination__right-arrow--disabled" if !last_page_num }}">
-      <a class="prev-link" href="{{ blog_page_link(last_page_num) }}">
+      <a class="blog-pagination__prev-link" href="{{ blog_page_link(last_page_num) }}">
         {% icon name="chevron-left" style="SOLID", width="13", no_wrapper=True %}
         Prev
       </a>
@@ -104,7 +104,7 @@
       {% endfor %}
     </div>
     <div class="blog-pagination__right-arrow {{ "blog-pagination__right-arrow--disabled" if !next_page_num }}">
-      <a class="next-link" href="{{ blog_page_link(current_page_num + 1) }}">
+      <a class="blog-pagination__next-link" href="{{ blog_page_link(current_page_num + 1) }}">
       Next
       {% icon name="chevron-right" style="SOLID", width="13", no_wrapper=True %}
       </a>


### PR DESCRIPTION
Fixes #39 

Restructures blog pagination markup and fixes alignment on desktop/mobile. Also hides pagination if there is only one page of blog posts.

Before: 
<img width="378" alt="image" src="https://user-images.githubusercontent.com/9009552/64719591-8dc21300-d496-11e9-9055-3cb3d2ba4226.png">

After: 
<img width="369" alt="image" src="https://user-images.githubusercontent.com/9009552/64719584-87cc3200-d496-11e9-8394-a89f87c8a8b4.png">
