### PR TITLE
Switch to page meta object

### DIFF
--- a/src/templates/layouts/base.html
+++ b/src/templates/layouts/base.html
@@ -2,9 +2,10 @@
 <html lang="{{ html_lang }}" {{ html_lang_dir }}>
   <head>
     <meta charset="utf-8">
-    <title>{{ content.html_title }}</title>
+    <title>{{ page_meta.html_title }}</title>
     {% if site_settings.favicon_src %}<link rel="shortcut icon" href="{{ site_settings.favicon_src }}" />{% endif %}
-    <meta name="description" content="{{ content.meta_description }}">
+    <meta name="description" content="{{ page_meta.meta_description }}">
+    <link rel="canonical" href="{{ page_meta.canonical_url }}">
     {{ require_css(get_public_template_url("../../css/layout.css")) }}
     {{ require_css(get_public_template_url("../../css/main.css")) }}
     {# where possible, improve page performance and speed by combining external http requests to reduce your

--- a/src/templates/layouts/base.html
+++ b/src/templates/layouts/base.html
@@ -5,7 +5,6 @@
     <title>{{ page_meta.html_title }}</title>
     {% if site_settings.favicon_src %}<link rel="shortcut icon" href="{{ site_settings.favicon_src }}" />{% endif %}
     <meta name="description" content="{{ page_meta.meta_description }}">
-    <link rel="canonical" href="{{ page_meta.canonical_url }}">
     {{ require_css(get_public_template_url("../../css/layout.css")) }}
     {{ require_css(get_public_template_url("../../css/main.css")) }}
     {# where possible, improve page performance and speed by combining external http requests to reduce your


### PR DESCRIPTION
Switches the base template to use the `page_met`a object for meta fields since those contain information about overrides coming from the CMS.