### PR TITLE
Update readme to remove ssh flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A straight-forward starting point for building a great website on the HubSpot CM
 The HubSpot CMS boilerplate is designed to work with both [local development](https://designers.hubspot.com/docs/tools/local-development) and the HubSpot Design Tools. To get started, you will need to have [Node.js](https://nodejs.org) installed. When getting started, we strongly suggest that you set up a [HubSpot CMS Developer Sandbox](https://offers.hubspot.com/free-cms-developer-sandbox).
 
 1. Navigate to the directory that you want to use for your project
-1. Run `npx @hubspot/create-cms-project --ssh <directory>` to create a project from the boilerplate
+1. Run `npx @hubspot/create-cms-project <directory>` to create a project from the boilerplate
 1. Create a `hubspot.config.yml` file and [configure](https://designers.hubspot.com/docs/tools/local-development#2-set-up-your-configuration-file) the CLI so that you can upload files to the HubSpot portals that you use
 1. Run `npx hscms watch --portal=<portal> src <directory>` to upload all the files in the boilerplate and [watch for changes](https://designers.hubspot.com/docs/tools/local-development-reference#watch) to files in the `src` directory
 


### PR DESCRIPTION
Fixes  #45 

Updates the instructions in /readme.md to remove the `-ssh` flag from the example command

![image](https://user-images.githubusercontent.com/9009552/64812033-6c335b00-d56c-11e9-965e-0c45724292bb.png)
