### PR TITLE
added some opinionated tablet styles

### DIFF
--- a/src/css/_header.css
+++ b/src/css/_header.css
@@ -37,6 +37,7 @@
   max-width: {{ page_logo_max_width }};
   height: auto;
   margin-left: 22px;
+  margin-right: auto;
   overflow: hidden;
 }
 
@@ -47,6 +48,10 @@
 .header__logo .logo-company-name {
   font-size: 28px;
   margin-top: 7px;
+}
+
+.header__logo--tablet {
+  display: none;
 }
 
 /* Styles for the Search Bar */
@@ -218,9 +223,25 @@
   border-top: 6px solid {{ body_color }};
 }
 
+/* Tablet Styles */
+
+@media (max-width: 1150px) and (min-width: 767px) {
+  .header__column {
+    width: 100%;
+  }
+
+  .header__logo--main {
+    display: none;
+  }
+
+  .header__logo--tablet {
+    display: block;
+  }
+}
+
 /* Mobile Styles */
 
-@media (max-width: 867px) {
+@media (max-width: 767px) {
   .header__container {
     flex-direction: column;
     padding: 20px 0 0;

--- a/src/css/_header.css
+++ b/src/css/_header.css
@@ -54,6 +54,10 @@
   display: none;
 }
 
+.header__logo--main {
+  padding-top: 20px;
+}
+
 /* Styles for the Search Bar */
 
 .header__search {

--- a/src/modules/Menu section.module/module.css
+++ b/src/modules/Menu section.module/module.css
@@ -173,6 +173,10 @@
     padding: 22px 15px;
   }
 
+  .submenu.level-1 > li:last-child {
+    padding-right: 22px;
+  }
+
   .submenu.level-1 > .has-submenu > .menu-arrow {
     top: 40px;
     right: 0px;

--- a/src/modules/Menu section.module/module.css
+++ b/src/modules/Menu section.module/module.css
@@ -46,6 +46,7 @@
 
 .submenu.level-1 {
   display: inline-block;
+  white-space: nowrap;
 }
 
 .submenu.level-1 > li {
@@ -163,7 +164,7 @@
 }
 
 
-@media (min-width: 868px) and (max-width: 1100px) {
+@media (min-width: 768px) and (max-width: 1150px) {
   .navigation-primary a {
     font-size: 20px;
   }
@@ -182,7 +183,7 @@
   }
 }
 
-@media (max-width: 867px) {
+@media (max-width: 767px) {
   .navigation-primary a {
     font-size: 26px;
   }

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -10,9 +10,9 @@
     <div class="header__column">
       <div class="header__row-1">
         <div class="header__logo header__logo--tablet">
-          <!-- This second logo module is for the tablet breakpoint,
+          {# This second logo module is for the tablet breakpoint,
           so that the menu can wrap underneath the logo without breaking onto a new line.
-          It's hidden unless in a tablet breakpoint.  -->
+          It's hidden unless in a tablet breakpoint.  #}
           {% module "site_logo" path="@hubspot/logo", label="Logo" %}
         </div>
         {% if content.translated_content|length %}

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -10,6 +10,9 @@
     <div class="header__column">
       <div class="header__row-1">
         <div class="header__logo header__logo--tablet">
+          <!-- This second logo module is for the tablet breakpoint,
+          so that the menu can wrap underneath the logo without breaking onto a new line.
+          It's hidden unless in a tablet breakpoint.  -->
           {% module "site_logo" path="@hubspot/logo", label="Logo" %}
         </div>
         {% if content.translated_content|length %}

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -4,11 +4,14 @@
 -->
 <header class="header">
   <div class="header__container">
-    <div class="header__logo">
+    <div class="header__logo header__logo--main">
       {% module "site_logo" path="@hubspot/logo", label="Logo" %}
     </div>
     <div class="header__column">
       <div class="header__row-1">
+        <div class="header__logo header__logo--tablet">
+          {% module "site_logo" path="@hubspot/logo", label="Logo" %}
+        </div>
         {% if content.translated_content|length %}
         <div class="header__language-switcher header--element">
           <div class="header__language-switcher--label">


### PR DESCRIPTION
Merged two of the discussed design styles, since the boilerplate home page menu was overlapping again. Previously, I bumped up the mobile breakpoint to "fix" this issue but this is my attempt at a more resilient solution. 

At 1150px, the tablet breakpoint takes place, moving the logo into the top column while the menu takes the space below it. The menu specifically has "nowrap" on it, so that an obscenely long menu won't cause an unsightly menu wrap. 

![Screen Shot 2019-10-01 at 3 45 47 PM](https://user-images.githubusercontent.com/48642024/65995132-db60e880-e462-11e9-8235-d74591352e2a.png)

![Screen Shot 2019-10-01 at 3 45 55 PM](https://user-images.githubusercontent.com/48642024/65995141-e0259c80-e462-11e9-899d-3f987ee0e435.png)

![Screen Shot 2019-10-01 at 3 46 08 PM](https://user-images.githubusercontent.com/48642024/65995144-e3208d00-e462-11e9-8d6b-1634c03f98b3.png)
