### PR TITLE
Remove module_id from menu section

### DIFF
--- a/src/modules/Menu section.module/meta.json
+++ b/src/modules/Menu section.module/meta.json
@@ -13,6 +13,5 @@
   "purchased": false,
   "smart_type": "NOT_SMART",
   "tags": [],
-  "module_id": 9793409,
   "is_available_for_new_content": false
 }


### PR DESCRIPTION
menu section is the only boilerplate module with a module_id. Removing it from boilerplate to make it more clear that developers should have their own unique instances of this menu module and avoid collisions.