### PR TITLE
Add membership templates

### DIFF
--- a/src/css/_forms.css
+++ b/src/css/_forms.css
@@ -3,7 +3,8 @@ form {
   font-family: {{ secondary_font_family }};
 }
 
-.hs-button {
+.hs-button,
+#hs-membership-form .hs-button {
   margin: 0;
   cursor: pointer;
   display: inline-block;
@@ -23,16 +24,22 @@ form {
 {# default "Get Free Widget" form (renders when no form is passed to the form HubL tag)
   is an anchor (a.hs-button) rather than a real input, so it needs explcit css to avoid link styling #}
   text-decoration: none;
+  width: auto;
+  height: auto;
 }
 
-.hs-button:hover, .hs-button:focus {
+.hs-button:hover, 
+.hs-button:focus,
+#hs-membership-form .hs-button:hover,
+#hs-membership-form .hs-button:focus {
   background-color: {{ form_button_color_hover }};
   border-color: {{ form_button_color_hover }};
 {# see "no form selected" note above #}
   color: {{ form_button_text_color }};
 }
 
-.hs-button:active {
+.hs-button:active,
+#hs-membership-form .hs-button:active {
   background-color: {{ form_button_color_active }};
   border-color: {{ form_button_color_active }};
 }
@@ -56,7 +63,8 @@ form {
   color: {{ form_error_label_color }};
 }
 
-.hs-input {
+.hs-input,
+#hs-membership-form input {
   display: inline-block;
   width: 100%;
   height: 58px;
@@ -75,7 +83,9 @@ form {
 }
 
 .hs-input[type=checkbox],
-.hs-input[type=radio] {
+.hs-input[type=radio],
+#hs-membership-form input[type=checkbox],
+#hs-membership-form input[type=radio] {
   cursor: pointer;
   width: auto;
   height: auto;
@@ -180,7 +190,9 @@ ul.no-list {
   list-style: none;
 }
 
-.field {
+.field,
+#hs-membership-form input,
+#hs-membership-form .hs-button {
   margin-bottom: 18px;
 }
 
@@ -252,7 +264,13 @@ ul.no-list {
 .hs-form-field input[type=number],
 .hs-form-field input[type=tel],
 .hs-form-field input[type=date],
-.hs-form-field textarea {
+.hs-form-field textarea,
+#hs-membership-form input[type=text],
+#hs-membership-form input[type=email],
+#hs-membership-form input[type=phone],
+#hs-membership-form input[type=number],
+#hs-membership-form input[type=tel],
+#hs-membership-form input[type=date], {
   -webkit-appearance: none;
   -moz-appearance: none;
 }

--- a/src/css/_forms.css
+++ b/src/css/_forms.css
@@ -3,8 +3,7 @@ form {
   font-family: {{ secondary_font_family }};
 }
 
-.hs-button,
-#hs-membership-form .hs-button {
+.hs-button {
   margin: 0;
   cursor: pointer;
   display: inline-block;
@@ -29,21 +28,17 @@ form {
 }
 
 .hs-button:hover, 
-.hs-button:focus,
-#hs-membership-form .hs-button:hover,
-#hs-membership-form .hs-button:focus {
+.hs-button:focus {
   background-color: {{ form_button_color_hover }};
   border-color: {{ form_button_color_hover }};
 {# see "no form selected" note above #}
   color: {{ form_button_text_color }};
 }
 
-.hs-button:active,
-#hs-membership-form .hs-button:active {
+.hs-button:active {
   background-color: {{ form_button_color_active }};
   border-color: {{ form_button_color_active }};
 }
-
 
 .hs-form label {
   font-size: .83rem;
@@ -63,8 +58,17 @@ form {
   color: {{ form_error_label_color }};
 }
 
-.hs-input,
-#hs-membership-form input {
+/* Membership error message */
+.form-input-validation-message ul {
+  padding-left: 0;
+  margin: 0;
+}
+
+.form-input-validation-message ul li {
+  line-height: 1rem;
+}
+
+.hs-input {
   display: inline-block;
   width: 100%;
   height: 58px;
@@ -83,9 +87,7 @@ form {
 }
 
 .hs-input[type=checkbox],
-.hs-input[type=radio],
-#hs-membership-form input[type=checkbox],
-#hs-membership-form input[type=radio] {
+.hs-input[type=radio] {
   cursor: pointer;
   width: auto;
   height: auto;
@@ -190,9 +192,7 @@ ul.no-list {
   list-style: none;
 }
 
-.field,
-#hs-membership-form input,
-#hs-membership-form .hs-button {
+.hs-form-field {
   margin-bottom: 18px;
 }
 
@@ -264,13 +264,7 @@ ul.no-list {
 .hs-form-field input[type=number],
 .hs-form-field input[type=tel],
 .hs-form-field input[type=date],
-.hs-form-field textarea,
-#hs-membership-form input[type=text],
-#hs-membership-form input[type=email],
-#hs-membership-form input[type=phone],
-#hs-membership-form input[type=number],
-#hs-membership-form input[type=tel],
-#hs-membership-form input[type=date], {
+.hs-form-field textarea {
   -webkit-appearance: none;
   -moz-appearance: none;
 }

--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -158,7 +158,8 @@ h3.form-title {
 }
 
 .hs-button,
-.button--primary {
+.button--primary,
+#hs-membership-form .hs-button {
   background-color: rgba({{ theme.buttons.background_color.color|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ theme.buttons.border_color.color|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   border-radius: {{ theme.buttons.border_radius }}px;
@@ -173,14 +174,17 @@ h3.form-title {
 .hs-button:hover,
 .hs-button:focus,
 .button--primary:hover,
-.button--primary:focus {
+.button--primary:focus,
+#hs-membership-form .hs-button:hover,
+#hs-membership-form .hs-button:focus {
   background-color: rgba({{ color_variant(theme.buttons.background_color.color, -40)|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ color_variant(theme.buttons.border_color.color, -40)|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   color: rgba({{ theme.buttons.text_color.color|convert_rgb }}, {{ theme.buttons.text_color.opacity * 0.01 }});
 }
 
 .hs-button:active,
-.button--primary:active {
+.button--primary:active,
+#hs-membership-form .hs-button:active {
   background-color: rgba({{ color_variant(theme.buttons.background_color.color, 40)|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ color_variant(theme.buttons.border_color.color, 40)|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   color: rgba({{ theme.buttons.text_color.color|convert_rgb }}, {{ theme.buttons.text_color.opacity * 0.01 }});

--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -158,8 +158,7 @@ h3.form-title {
 }
 
 .hs-button,
-.button--primary,
-#hs-membership-form .hs-button {
+.button--primary {
   background-color: rgba({{ theme.buttons.background_color.color|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ theme.buttons.border_color.color|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   border-radius: {{ theme.buttons.border_radius }}px;
@@ -174,31 +173,29 @@ h3.form-title {
 .hs-button:hover,
 .hs-button:focus,
 .button--primary:hover,
-.button--primary:focus,
-#hs-membership-form .hs-button:hover,
-#hs-membership-form .hs-button:focus {
+.button--primary:focus {
   background-color: rgba({{ color_variant(theme.buttons.background_color.color, -40)|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ color_variant(theme.buttons.border_color.color, -40)|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   color: rgba({{ theme.buttons.text_color.color|convert_rgb }}, {{ theme.buttons.text_color.opacity * 0.01 }});
 }
 
 .hs-button:active,
-.button--primary:active,
-#hs-membership-form .hs-button:active {
+.button--primary:active {
   background-color: rgba({{ color_variant(theme.buttons.background_color.color, 40)|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ color_variant(theme.buttons.border_color.color, 40)|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   color: rgba({{ theme.buttons.text_color.color|convert_rgb }}, {{ theme.buttons.text_color.opacity * 0.01 }});
 }
 
-.hs-form label {
+form label {
   color: rgba({{ theme.forms.label_color.color|convert_rgb }}, {{ theme.forms.label_color.opacity * 0.01 }});
 }
 
-.hs-form legend {
+form legend {
   color: rgba({{ theme.forms.help_text_color.color|convert_rgb }}, {{ theme.forms.help_text_color.opacity * 0.01 }});
 }
 
 form input,
+form .hs-input,
 form select,
 form textarea {
   border-color: rgba({{ theme.forms.field_border_color.color|convert_rgb }}, {{ theme.forms.field_border_color.opacity * 0.01 }});
@@ -206,6 +203,7 @@ form textarea {
 }
 
 form input:focus,
+form .hs-input:focus,
 form select:focus,
 form textarea:focus {
   border-color: rgba({{ theme.forms.field_focus_border_color.color|convert_rgb }}, {{ theme.forms.field_focus_border_color.opacity * 0.01 }});

--- a/src/templates/system/membership_login.html
+++ b/src/templates/system/membership_login.html
@@ -1,0 +1,32 @@
+<!--
+  templateType: membership_login_page
+  isAvailableForNewContent: true
+  label: Membership Login Page
+-->
+{% extends '../layouts/base.html' %}
+
+{% block header %}
+{% endblock %}
+
+{% block body %}
+<main class="body-container-wrapper">
+  <section class="content-wrapper">
+    <div class="systems-page">
+      <h2>Sign in to view this page</h2>
+      <p class="introduction">This page is only available to people who have been given access.</p>
+      <div class="form-container">
+        {% member_login 'my_login'
+          email_label= 'Email',
+          password_label= 'Password',
+          remember_me_label= 'Remember Me',
+          reset_password_text= 'Forgot your password?',
+          submit_button_text= 'Login'
+        %}
+      </div>
+      <div>
+        <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/src/templates/system/membership_register.html
+++ b/src/templates/system/membership_register.html
@@ -1,0 +1,31 @@
+<!--
+  templateType: membership_register_page
+  isAvailableForNewContent: true
+  label: Membership Registration
+-->
+{% extends '../layouts/base.html' %}
+
+{% block header %}
+{% endblock %}
+
+{% block body %}
+<main class="body-container-wrapper">
+  <section class="content-wrapper">
+    <div class="systems-page">
+      <h2>Welcome!</h2>
+      <p class="introduction">Set up your password to sign in and see the content you now have access to.</p>
+      <div class="form-container">
+        {% member_register 'my_register'
+          email_label='Email',
+          password_confirm_label='Confirm Password',
+          password_label='Password',
+          submit_button_text='Save Password'
+        %}
+      </div>
+      <div>
+        <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/src/templates/system/membership_reset_password.html
+++ b/src/templates/system/membership_reset_password.html
@@ -1,0 +1,30 @@
+<!--
+  templateType: membership_reset_page
+  isAvailableForNewContent: true
+  label: Reset Password Page
+-->
+{% extends '../layouts/base.html' %}
+
+{% block header %}
+{% endblock %}
+
+{% block body %}
+<main class="body-container-wrapper">
+  <section class="content-wrapper">
+    <div class="systems-page">
+      <h2>Reset your password</h2>
+      <p class="introduction">Enter a new password.</p>
+      <div class="form-container">
+        {% password_reset 'my_password_reset'
+          password_confirm_label='Confirm Password',
+          password_label='Password',
+          submit_button_text= 'Save Password'
+        %}
+      </div>
+      <div>
+        <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/src/templates/system/membership_reset_password_request.html
+++ b/src/templates/system/membership_reset_password_request.html
@@ -1,0 +1,29 @@
+<!--
+  templateType: membership_reset_request_page
+  isAvailableForNewContent: true
+  label: Reset Password Request Page
+-->
+{% extends '../layouts/base.html' %}
+
+{% block header %}
+{% endblock %}
+
+{% block body %}
+<main class="body-container-wrapper">
+  <section class="content-wrapper">
+    <div class="systems-page">
+      <h2>Reset your password</h2>
+      <p class="introduction">What email address should we send a password reset email to?</p>
+      <div class="form-container">
+        {% password_reset_request 'my_password_reset_request'
+          email_label='Email',
+          submit_button_text='Send Reset Email'
+        %}
+      </div>
+      <div>
+        <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}


### PR DESCRIPTION
Adds 4 template types:
- Membership Registration (`membership_register_page`)
- Membership Login Page (`membership_login_page`)
- Reset Password Request Page (`membership_reset_request_page`)
- Reset Password Page (`membership_reset_page`)

Membership registration access allows users to publish permissions that can control which contacts can access HubSpot-hosted pages, blogs, and knowledge base articles.

**Note:** Membership templates are only available to Marketing Hub Professions, Marketing Hub Enterprise, and CMS accounts. To learn more please see the [Membership Registration documentation](https://knowledge.hubspot.com/cms-pages-editor/control-audience-access-to-pages).

Fixes #74 