### PR TITLE
adding `white-space: normal;` to CSS for buttons

### DIFF
--- a/src/css/_forms.css
+++ b/src/css/_forms.css
@@ -20,6 +20,7 @@ form {
   border-width: 1px;
   font-size: .92rem;
   padding: 15px 53px;
+  white-space: normal;
 {# default "Get Free Widget" form (renders when no form is passed to the form HubL tag)
   is an anchor (a.hs-button) rather than a real input, so it needs explcit css to avoid link styling #}
   text-decoration: none;

--- a/src/css/_forms.css
+++ b/src/css/_forms.css
@@ -21,6 +21,7 @@ form {
   font-size: .92rem;
   padding: 15px 53px;
   white-space: normal;
+  word-break: break-word;
 {# default "Get Free Widget" form (renders when no form is passed to the form HubL tag)
   is an anchor (a.hs-button) rather than a real input, so it needs explcit css to avoid link styling #}
   text-decoration: none;


### PR DESCRIPTION
Updating the styles for buttons so that `white-space: normal;` is added. This prevents the buttons from extending across the page instead of wrapping the text at the container width, which is the expected behavior.