### PR TITLE
the yaml key should be availableTo... not isAvailableTo...

### DIFF
--- a/cms-deploy.yaml
+++ b/cms-deploy.yaml
@@ -2,8 +2,8 @@ deployable: cms-theme-boilerplate
 repoName: cms-theme-boilerplate
 themePath: @hubspot/boilerplate
 
-isAvailableToScaffold: true
-isAvailableToDownload: false
+availableToScaffold: true
+availableToDownload: false
 
 notificationSlackChannel: content-design-assets
 


### PR DESCRIPTION
I always accidentally add the `is` when deserializing boolean values, but the field shouldn't have that in the YAML to get serialized into the POJO correctly