### PR TITLE
Updating button class name

### DIFF
--- a/src/css/_forms.css
+++ b/src/css/_forms.css
@@ -3,6 +3,8 @@ form {
   font-family: {{ secondary_font_family }};
 }
 
+button,
+.button,
 .hs-button {
   margin: 0;
   cursor: pointer;
@@ -29,7 +31,11 @@ form {
   height: auto;
 }
 
-.hs-button:hover, 
+button:hover,
+button:focus,
+.button:hover,
+.button:focus,
+.hs-button:hover,
 .hs-button:focus {
   background-color: {{ form_button_color_hover }};
   border-color: {{ form_button_color_hover }};
@@ -37,6 +43,8 @@ form {
   color: {{ form_button_text_color }};
 }
 
+button:active,
+.button:active,
 .hs-button:active {
   background-color: {{ form_button_color_active }};
   border-color: {{ form_button_color_active }};

--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -157,8 +157,9 @@ h3.form-title {
   color: rgba({{ theme.forms.header_text_color.color|convert_rgb }}, {{ theme.forms.header_text_color.opacity * 0.01 }});
 }
 
-.hs-button,
-.button--primary {
+button,
+.button,
+.hs-button {
   background-color: rgba({{ theme.buttons.background_color.color|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ theme.buttons.border_color.color|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   border-radius: {{ theme.buttons.border_radius }}px;
@@ -170,17 +171,20 @@ h3.form-title {
   padding-bottom: {{ theme.buttons.vertical_padding }}px;
 }
 
+button:hover,
+button:focus,
+.button:hover,
+.button:focus,
 .hs-button:hover,
-.hs-button:focus,
-.button--primary:hover,
-.button--primary:focus {
+.hs-button:focus {
   background-color: rgba({{ color_variant(theme.buttons.background_color.color, -40)|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ color_variant(theme.buttons.border_color.color, -40)|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   color: rgba({{ theme.buttons.text_color.color|convert_rgb }}, {{ theme.buttons.text_color.opacity * 0.01 }});
 }
 
-.hs-button:active,
-.button--primary:active {
+button:active,
+.button:active,
+.hs-button:active {
   background-color: rgba({{ color_variant(theme.buttons.background_color.color, 40)|convert_rgb }}, {{ theme.buttons.background_color.opacity * 0.01 }});
   border-color: rgba({{ color_variant(theme.buttons.border_color.color, 40)|convert_rgb }}, {{ theme.buttons.border_color.opacity * 0.01 }});
   color: rgba({{ theme.buttons.text_color.color|convert_rgb }}, {{ theme.buttons.text_color.opacity * 0.01 }});

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -8,7 +8,7 @@
   {% endunless %}
 {% endif %}
 {% set rel = (module.link.open_in_new_tab ? 'noopener ' : null) ~ (module.link.no_follow ? 'nofollow' : null) %}
-<a class="hs-button " href="{{ href }}"
+<a class="button" href="{{ href }}"
    {% if module.link.open_in_new_tab %}target="_blank"{% endif %}
    rel ="{{ rel }}">
   {{ module.button_text }}

--- a/src/templates/system/404.html
+++ b/src/templates/system/404.html
@@ -12,7 +12,7 @@
     <h1 class="error-page_heading">
       Page not found.
     </h1>
-    <a class="hs-button" href="/">Go Home</a>
+    <a class="button" href="/">Go Home</a>
   </div>
 </div>
 {% endblock body %}


### PR DESCRIPTION
Replacing instances of `hs-button` with `button` on non HubSpot generated buttons (e.g. the form submit button). 

Fixes #61 and will replace (https://github.com/HubSpot/cms-theme-boilerplate/pull/62). This needed to be fixed up first so that I could start style guiding templates (as `hs-button` was used on the 404 error template). 