### PR TITLE
Removing home.css reference in main.css

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -9,6 +9,5 @@
 {% include './elements/_menus.css' %}
 {% include './components/_header.css' %}
 {% include './components/_footer.css' %}
-{% include './templates/_home.css' %}
 {% include './templates/_blog.css' %}
 {% include './templates/_system.css' %}


### PR DESCRIPTION
Removing `_home.css` reference in `main.css` as that template was removed. 

CC: @ckconant @TanyaScales 

Fixes #134 