### PR TITLE
Adding template and theme screenshots

### DIFF
--- a/src/templates/partials/header-no-navigation.html
+++ b/src/templates/partials/header-no-navigation.html
@@ -3,7 +3,7 @@
   label: Header no navigation
 -->
 <header class="header header--no-navigation">
-  <div class="header__container">
+  <div class="header__container content-wrapper">
     <div class="header__logo">
       {% module 'site_logo' path='@hubspot/logo' %}
     </div>


### PR DESCRIPTION
- Adding `content-wrapper` class to header no nav partial (was previously incorrect)
- Adding screenshots to `theme.json` and templates 

Fixes #79 
Fixes #128 

CC: @TanyaScales @ckconant 