### PR TITLE
Fixing theme JSON for font size

### DIFF
--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -117,7 +117,7 @@
 {###########################################################################}
 
 html {
-  font-size: {{ body_font.size ~ base_font.size_unit }};
+  font-size: {{ body_font.size ~ body_font.size_unit }};
 }
 
 body {

--- a/src/fields.json
+++ b/src/fields.json
@@ -148,10 +148,8 @@
           }
         },
         "default": {
-          "size": {
-            "units": "px",
-            "value": 24
-          }
+          "size": 24,
+          "size_unit": "px"
         }
       },
       {
@@ -167,14 +165,12 @@
           }
         },
         "default": {
-          "size": {
-            "units": "px",
-            "value": 50
-          },
-          "variant": "700",
+          "size": 50,
+          "size_unit": "px",
           "styles": {
             "text-decoration" : "none"
-          }
+          },
+          "variant": "700"
         }
       },
       {
@@ -190,14 +186,12 @@
           }
         },
         "default": {
-          "size": {
-            "units": "px",
-            "value": 38
-          },
-          "variant": "700",
+          "size": 38,
+          "size_unit": "px",
           "styles": {
             "text-decoration" : "none"
-          }
+          },
+          "variant": "700"
         }
       },
       {
@@ -213,14 +207,12 @@
           }
         },
         "default": {
-          "size": {
-            "units": "px",
-            "value": 30
-          },
-          "variant": "700",
+          "size": 30,
+          "size_unit": "px",
           "styles": {
             "text-decoration" : "none"
-          }
+          },
+          "variant": "700"
         }
       },
       {
@@ -236,10 +228,8 @@
           }
         },
         "default": {
-          "size": {
-            "units": "px",
-            "value": 24
-          },
+          "size": 24,
+          "size_unit": "px",
           "styles": {
             "text-decoration" : "none"
           }
@@ -258,10 +248,8 @@
         },
         "default": {
           "color": "#000000",
-          "size": {
-            "units": "px",
-            "value": 16
-          },
+          "size": 16,
+          "size_unit": "px",
           "styles": {
             "text-decoration" : "none"
           }
@@ -280,10 +268,8 @@
           }
         },
         "default": {
-          "size": {
-            "units": "px",
-            "value": 14
-          },
+          "size": 14,
+          "size_unit": "px",
           "styles": {
             "text-decoration" : "none"
           }


### PR DESCRIPTION
Fixes #146 

The goal was to update the different font size references in the `fields.json` file of the theme. They were previously using an outdated approach and the outdated approach was being incorrectly referenced in `theme-overrides.css` which was causing an issue in the CSS and breaking CSS combining. The fix updates `fields.json` font size fields to match [our documentation](https://designers.hubspot.com/docs/building-blocks/module-theme-fields#font) and fixes references to the font fields from `theme-overrides.css`. 

We'll be making a patch release once we're able to ensure CSS combining is working after this fix. 