### PR TITLE
Removing line height on search results input

### DIFF
--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -82,7 +82,6 @@
   font-size: 22px;
   font-weight: 300;
   height: 45px;
-  line-height: 42;
   padding: 0 15px;
 }
 


### PR DESCRIPTION
Removes line-height that was set on the search bar input which fixes the height.

**Example link:** (http://jrosa-102019231.hs-sitesqa.com/test)

Fixes #151 