### PR TITLE
Add link target to the menu links

### DIFF
--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -22,10 +22,16 @@
  }}
 {% endmacro %}
 
+{% macro linkTarget() %}
+{{
+{"target": "_blank"}|xmlattr
+}}
+{% endmacro %}
+
 {% macro link(node) %}
 
 <li {{ childClasses() if node.children else defaultItemClasses() }}>
-  <a class="menu-link" href="{{ node.url }}" {{ activeNode() if node.activeNode }}>{{ node.label }}</a>
+  <a class="menu-link" href="{{ node.url }}" {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }}>{{ node.label }}</a>
 
   {% if node.children %}
   <input type="checkbox" id="{{ node.label }}" class="submenu-toggle">


### PR DESCRIPTION
Add link target to menu links (previously wasn't set). 

Example page (About has target set: http://jrosa-102019231.hs-sitesqa.com/?hs_preview=WeodDwqu-4182245376). 

Fixes #121 