### PR TITLE
Removing locked option for the menu field on the menu module

### DIFF
--- a/src/modules/menu-section.module/fields.json
+++ b/src/modules/menu-section.module/fields.json
@@ -2,7 +2,6 @@
   {
     "label": "Primary menu field",
     "name": "primary_menu_field",
-    "type": "menu",
-    "locked": true
+    "type": "menu"
   }
 ]


### PR DESCRIPTION
Removing the `locked` parameter on the menu field in the menu module. For context the `locked` parameter can be found under properties used by all fields here (https://designers.hubspot.com/docs/building-blocks/module-theme-fields#properties-used-by-all-fields). This was previously set to true and we are removing it so that it is now set back to the default of false as we want the menu field to be editable in content editors. 