### PR TITLE
Updating the version number to v1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cms-theme-boilerplate",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Boilerplate project for building websites on the HubSpot CMS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update boilerplate version number to v1.2.3 to support patch release of template/theme screenshots. 