### PR TITLE
Adding fallback for menu items without link

### DIFF
--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -31,7 +31,7 @@
 {% macro link(node) %}
 
 <li {{ childClasses() if node.children else defaultItemClasses() }}>
-  <a class="menu-link" href="{{ node.url }}" {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }}>{{ node.label }}</a>
+  <a class="menu-link" href="{{ node.url if node.url else 'javascript:;' }}" {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }}>{{ node.label }}</a>
 
   {% if node.children %}
   <input type="checkbox" id="{{ node.label }}" class="submenu-toggle">


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds `javascript:;` as the `href` for menu items that don't have a link included. 

**Relevant links**

Example page: http://jrosa-102019231.hs-sitesqa.com/?hs_preview=QQSeqjXf-4195682433
GitHub issue: Fixes #168 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

