### PR TITLE
Fix faulty semicolon

### DIFF
--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -107,7 +107,7 @@
             <article class="blog-index__post blog-index__post--large">
               <a class="blog-index__post-image blog-index__post-image--large"
                 {% if content.featured_image %}
-                  style="background-image: url('{{ content.featured_image }}')";
+                  style="background-image: url('{{ content.featured_image }}');"
                 {% endif %}
                 href="{{ content.absolute_url }}"></a>
               <div class="blog-index__post-content  blog-index__post-content--large">
@@ -119,7 +119,7 @@
             <article class="blog-index__post blog-index__post--small">
               <a class="blog-index__post-image blog-index__post-image--small"
                 {% if content.featured_image %}
-                  style="background-image: url('{{ content.featured_image }}')";
+                  style="background-image: url('{{ content.featured_image }}');"
                 {% endif %}
                 href="{{ content.absolute_url }}"></a>
               <div class="blog-index__post-content  blog-index__post-content--small">


### PR DESCRIPTION


**Types of change**

- [x] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

The semicolon used to close the `background-image` element was outside the `style=""` tag. I've moved it in to the correc tposition.

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.