### PR TITLE
Replacing this with el in menu JS

### DIFF
--- a/src/modules/menu-section.module/module.js
+++ b/src/modules/menu-section.module/module.js
@@ -7,11 +7,11 @@
   Array.prototype.forEach.call(parentMenuItems, function(el){
 
     el.addEventListener('focusin', function(){
-      this.classList.add('focus');
+      el.classList.add('focus');
     });
 
     el.addEventListener('focusout', function(){
-      this.classList.remove('focus');
+      el.classList.remove('focus');
     });
 
   });


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

In the menu module JavaScript, I replaced `this` with `el` within the event listeners to improve upon the readability of the code. 

**Relevant links**

Example page: https://preview.hs-sitesqa.com/_hcms/preview/template/multi?domain=undefined&portalId=102019231&tc_deviceCategory=undefined&template_file_path=CMSBoilerplate/templates/home.html&updated=1589811518449
GitHub reference: https://github.com/HubSpot/cms-theme-boilerplate/pull/169#discussion_r438434699

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
