### PR TITLE
Fixing menu hover overlap issue

### DIFF
--- a/src/modules/menu-section.module/module.css
+++ b/src/modules/menu-section.module/module.css
@@ -316,6 +316,7 @@
     transform: unset;
     visibility: visible;
     width: 100%;
+    z-index: 2;
   }
 
   .submenu.level-2 .menu-item {


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Previously the menu drop downs were going behind the form in the blog listing template banner. I bumped up the z-index of the drop down menus to 2 so this was no longer an issue. Please note if you use modules with a z-index higher than 2 that you may need to bump up the menu drop down z-index to be a bit higher if it is supposed to overlap the new module. 

**Relevant links**

Fixes #157 

<img width="439" alt="Screen Shot 2020-06-16 at 1 31 36 PM" src="https://user-images.githubusercontent.com/22665237/84807835-d5516e80-afd5-11ea-9605-40b44adfbb40.png">

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
