### PR TITLE
Adding link field to price card button module

### DIFF
--- a/src/modules/pricing-card.module/fields.json
+++ b/src/modules/pricing-card.module/fields.json
@@ -41,6 +41,21 @@
     "default": "Sign up for free"
   },
   {
+    "label" : "Button link",
+    "name" : "button_link",
+    "type" : "link",
+    "supported_types" : [ "EXTERNAL", "CONTENT", "EMAIL_ADDRESS" ],
+    "default" : {
+      "url" : {
+        "content_id" : null,
+        "type" : "EXTERNAL",
+        "href" : ""
+      },
+      "open_in_new_tab" : false,
+      "no_follow" : false
+    }
+  },
+  {
     "label": "Features list icon bullet",
     "name": "feature_icon",
     "type": "icon",

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -8,6 +8,19 @@
     color: module.button_text_color.color
   }
 -%}
+
+{% if module.button_link.url.type is equalto 'EMAIL_ADDRESS' %}
+  {% set href = 'mailto:' ~ module.button_link.url.href %}
+{% else %}
+  {% unless (module.button_link.url.href is string_containing '//') or !module.button_link.url.href %}
+    {% set href = '//' ~ module.button_link.url.href %}
+  {% else %}
+    {% set href = module.button_link.url.href || '' %}
+  {% endunless %}
+{% endif %}
+
+{% set rel = (module.button_link.open_in_new_tab ? 'noopener ' : null) ~ (module.button_link.no_follow ? 'nofollow' : null) %}
+
 <div class="card card--pricing">
   {% if module.tier and module.description %}
     <div class="card__header">
@@ -36,6 +49,6 @@
     </ul>
     <hr>
     <h3 class="card__heading">{{ module.price }}</h3>
-    <button class="button card__button" type="button" style="{{ inlineDynamicButtonStyles(buttonStyles) }}">{{ module.button_text }}</button>
+    <{% if href %}a href="{{ href }}"{% if rel %} rel="{{ rel }}" {% endif %} {% if module.button_link.open_in_new_tab %}target="_blank"{% endif %}{% else %}button{% endif %} class="button" style="{{ inlineDynamicButtonStyles(buttonStyles) }}">{{ module.button_text }}</{% if href %}a {% else %}button{% endif %}>
   </div>
 </div>


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Previously there was not a link option for the pricing card module. This PR adds a link field to the button at the bottom of the pricing card. 

**Relevant links**

Fixes #173 

<img width="359" alt="ButtonLink" src="https://user-images.githubusercontent.com/22665237/84931409-c4216400-b0a0-11ea-8cb1-7a36bf6a5770.png">

<img width="825" alt="ButtonLinkCode" src="https://user-images.githubusercontent.com/22665237/84931419-c71c5480-b0a0-11ea-8c8e-71573c92a439.png">


**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
