### PR TITLE
Adjusting system template max-width

### DIFF
--- a/src/css/templates/_system.css
+++ b/src/css/templates/_system.css
@@ -36,7 +36,7 @@
 
 .systems-page {
   margin: 0 auto;
-  max-width: 500px;
+  max-width: 700px;
   padding: 3rem 1.4rem;
 }
 


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Widening out the max-width on system templates to account for larger heading sizes (previously large heading sizes weren't fitting in the specified container). 

**Relevant links**

Fixes #141 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.