### PR TITLE
Improve website grader score

### DIFF
--- a/src/templates/contact.html
+++ b/src/templates/contact.html
@@ -29,21 +29,24 @@
             card=[
               {
                 'image': {
-                  'src': get_asset_url('../images/phone.png')
+                  'src': get_asset_url('../images/phone.png'),
+                  'alt': 'Phone number'
                 },
                 'text': '(887) 929-0687',
                 'title': ''
               },
               {
                 'image': {
-                  'src': get_asset_url('../images/email.png')
+                  'src': get_asset_url('../images/email.png'),
+                  'alt': 'Email'
                 },
                 'text': 'contact@business.com',
                 'title': ''
               },
               {
                 'image': {
-                  'src': get_asset_url('../images/location.png')
+                  'src': get_asset_url('../images/location.png'),
+                  'alt': 'Address'
                 },
                 'text': '2 Canal Park, Cambridge, MA 02141',
                 'title': ''

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -147,7 +147,7 @@
         {% end_dnd_row %}
         {% dnd_row %}
           {% dnd_module path='../modules/customizable-button',
-            button_text='CLICK HERE',
+            button_text='Learn More',
             horizontal_alignment='CENTER'
           %}
           {% end_dnd_module %}

--- a/src/templates/layouts/base.html
+++ b/src/templates/layouts/base.html
@@ -10,7 +10,6 @@
       overall number of calls -- here, you can use a single call to the gFonts api to get all the fonts you need
       https://developers.google.com/fonts/docs/getting_started
     #}
-    {{ require_css("https://fonts.googleapis.com/css?family=Merriweather:400,700|Lato:400,700&display=swap") }}
     {# Include theme overrides #}
     {{ require_css(get_asset_url('../../css/theme-overrides.css')) }}
     {{ require_js(get_asset_url('../../js/main.js')) }}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Making a couple of small tweaks to improve the out of the box HubSpot website grader score for the HubSpot CMS Boilerplate. Currently, after adding meta descriptions for each page on (https://boilerplate.hubspotcms.com/), the website grader score is 92. 
- There was a note to be more specific with the home page button text of "Click Here" so I swapped that with "Learn More". 
- There was a note in the optimize tab of the contact page that said images didn't have alt text so I added some alt text for this.
- We were still including the fallback Google font which wasn't needed after updating boilerplate to use themes. This likely won't make a large impact but I'm removing it so that there is one less page request. 

This should likely get us to a ~97 for the website grader score with these improvements. 

**Relevant links**

Related to #181 #180 

<img width="190" alt="Screen Shot 2020-06-17 at 4 59 00 PM" src="https://user-images.githubusercontent.com/22665237/84950429-e4f7b280-b0bc-11ea-9bad-2277e497f87a.png">

<img width="256" alt="Screen Shot 2020-06-17 at 4 59 09 PM" src="https://user-images.githubusercontent.com/22665237/84950434-e7f2a300-b0bc-11ea-8dd2-0a0c06fc6af8.png">

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
