### PR TITLE
Fixing inherited pathfor button background color

### DIFF
--- a/src/fields.json
+++ b/src/fields.json
@@ -300,7 +300,9 @@
         "name": "background_color",
         "type": "color",
         "inherited_value": {
-          "default_value_path": "theme.global_colors.primary_color"
+          "property_value_paths": {
+            "color": "theme.global_colors.primary_color.color"
+          }
         },
         "default": {
           "opacity": 100


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

The button hover/active was not working properly. Based on how we had it set up the opacity of the rgba that we had for the background color was going to 0. After looking into this further, it looks like `themes.buttons.background_color.opacity` wasn't working at all. When checking out the `fields.json` this then made sense as the background color field on the button was pulling from one of the primary colors (which didn't have an opacity set/it was hidden). So I only inherited the color and not the opacity from the primary color. 

**Relevant links**

Fixes #178 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
