### PR TITLE
Fix links

### DIFF
--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -1,15 +1,20 @@
-{% if module.link.url.type is equalto 'EMAIL_ADDRESS' %}
-  {% set href = 'mailto:' ~ module.link.url.href %}
-{% else %}
-  {% unless (module.link.url.href is string_containing '//') or !module.link.url.href %}
-    {% set href = '//' ~ module.link.url.href %}
-  {% else %}
-    {% set href = module.link.url.href || '' %}
-  {% endunless %}
-{% endif %}
-{% set rel = (module.link.open_in_new_tab ? 'noopener ' : null) ~ (module.link.no_follow ? 'nofollow' : null) %}
-<a class="button" href="{{ href }}"
-   {% if module.link.open_in_new_tab %}target="_blank"{% endif %}
-   rel ="{{ rel }}">
+{% macro setLinkAttributes(field) %}
+  {% set href = (field.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ field.url.href : field.url.href %}
+  {% if href %}
+    {{ {'href': '{{ href }}'}|xmlattr }}
+  {% endif %}
+
+  {% if field.open_in_new_tab and field.no_follow %}
+    {{ {'rel': 'noopener nofollow'}|xmlattr }}
+    {{ {'target': '_blank'}|xmlattr }}
+  {% elif field.open_in_new_tab %}
+    {{ {'rel': 'noopener'}|xmlattr }}
+    {{ {'target': '_blank'}|xmlattr }}
+  {% elif field.no_follow %}
+    {{ {'rel': 'nofollow'}|xmlattr }}
+  {% endif %}
+{% endmacro %}
+
+<a class="button" {{ setLinkAttributes(module.link) }}>
   {{ module.button_text }}
 </a>

--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -45,7 +45,8 @@
 {% macro linkTarget() %}
 {{
   {
-    'target': '_blank'
+    'target': '_blank',
+    'rel': 'noopener'
   }|xmlattr
 }}
 {% endmacro %}

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -54,7 +54,7 @@
     </ul>
     <hr>
     <h3 class="card__heading">{{ module.price }}</h3>
-    <a {{ setLinkAttributes(module.button_link) }} class="button" style="{{ inlineDynamicButtonStyles(buttonStyles) }}">
+    <a class="button" {{ setLinkAttributes(module.button_link) }} style="{{ inlineDynamicButtonStyles(buttonStyles) }}">
       {{ module.button_text }}
     </a>
   </div>

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -9,17 +9,22 @@
   }
 -%}
 
-{% if module.button_link.url.type is equalto 'EMAIL_ADDRESS' %}
-  {% set href = 'mailto:' ~ module.button_link.url.href %}
-{% else %}
-  {% unless (module.button_link.url.href is string_containing '//') or !module.button_link.url.href %}
-    {% set href = '//' ~ module.button_link.url.href %}
-  {% else %}
-    {% set href = module.button_link.url.href || '' %}
-  {% endunless %}
-{% endif %}
+{% macro setLinkAttributes(field) %}
+  {% set href = (field.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ field.url.href : field.url.href %}
+  {% if href %}
+    {{ {'href': '{{ href }}'}|xmlattr }}
+  {% endif %}
 
-{% set rel = (module.button_link.open_in_new_tab ? 'noopener ' : null) ~ (module.button_link.no_follow ? 'nofollow' : null) %}
+  {% if field.open_in_new_tab and field.no_follow %}
+    {{ {'rel': 'noopener nofollow'}|xmlattr }}
+    {{ {'target': '_blank'}|xmlattr }}
+  {% elif field.open_in_new_tab %}
+    {{ {'rel': 'noopener'}|xmlattr }}
+    {{ {'target': '_blank'}|xmlattr }}
+  {% elif field.no_follow %}
+    {{ {'rel': 'nofollow'}|xmlattr }}
+  {% endif %}
+{% endmacro %}
 
 <div class="card card--pricing">
   {% if module.tier and module.description %}
@@ -49,6 +54,8 @@
     </ul>
     <hr>
     <h3 class="card__heading">{{ module.price }}</h3>
-    <{% if href %}a href="{{ href }}"{% if rel %} rel="{{ rel }}" {% endif %} {% if module.button_link.open_in_new_tab %}target="_blank"{% endif %}{% else %}button{% endif %} class="button" style="{{ inlineDynamicButtonStyles(buttonStyles) }}">{{ module.button_text }}</{% if href %}a {% else %}button{% endif %}>
+    <a {{ setLinkAttributes(module.button_link) }} class="button" style="{{ inlineDynamicButtonStyles(buttonStyles) }}">
+      {{ module.button_text }}
+    </a>
   </div>
 </div>

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -1,3 +1,20 @@
+{% macro setLinkAttributes(field) %}
+  {% set href = (field.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ field.url.href : field.url.href %}
+  {% if href %}
+    {{ {'href': '{{ href }}'}|xmlattr }}
+  {% endif %}
+
+  {% if field.open_in_new_tab and field.no_follow %}
+    {{ {'rel': 'noopener nofollow'}|xmlattr }}
+    {{ {'target': '_blank'}|xmlattr }}
+  {% elif field.open_in_new_tab %}
+    {{ {'rel': 'noopener'}|xmlattr }}
+    {{ {'target': '_blank'}|xmlattr }}
+  {% elif field.no_follow %}
+    {{ {'rel': 'nofollow'}|xmlattr }}
+  {% endif %}
+{% endmacro %}
+
 <div class="social-links">
   {% for item in module.social_links %}
     {% if item.social_account != 'custom_icon' %}
@@ -5,16 +22,7 @@
     {% else %}
       {% set social_icon = item.custom_icon.name %}
     {% endif %}
-    {% set href = item.social_link.url.href %}
-    {% if item.social_link.url.type is equalto 'EMAIL_ADDRESS' %}
-      {% set href = 'mailto:' + href %}
-    {% endif %}
-    {% set rel = (item.social_link.open_in_new_tab ? 'noopener ' : null) ~ (item.social_link.no_follow ? 'nofollow' : null) %}
-    <a href="{{ href }}"
-        class="social-links__link"
-      {% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
-      rel ="{{ rel }}"
-      >
+    <a class="social-links__link" {{ setLinkAttributes(item.social_link) }}>
       {% icon
         extra_classes='social-links__icon',
         name='{{ social_icon }}',

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -9,10 +9,11 @@
     {% if item.social_link.url.type is equalto 'EMAIL_ADDRESS' %}
       {% set href = 'mailto:' + href %}
     {% endif %}
+    {% set rel = (item.social_link.open_in_new_tab ? 'noopener ' : null) ~ (item.social_link.no_follow ? 'nofollow' : null) %}
     <a href="{{ href }}"
         class="social-links__link"
       {% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
-      {% if item.social_link.no_follow %}rel="nofollow"{% endif %}
+      rel ="{{ rel }}"
       >
       {% icon
         extra_classes='social-links__icon',

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -24,7 +24,7 @@
           {% if blog_author.has_social_profiles %}
             <div class="blog-header__author-social-links">
               {% if blog_author.website %}
-                <a href="{{ blog_author.website }}" target="_blank">
+                <a href="{{ blog_author.website }}" target="_blank" rel="noopener">
                   {% icon
                     name='link',
                     purpose='semantic',
@@ -35,7 +35,7 @@
                 </a>
               {% endif %}
               {% if blog_author.facebook %}
-                <a href="{{ blog_author.facebook }}" target="_blank">
+                <a href="{{ blog_author.facebook }}" target="_blank" rel="noopener">
                   {% icon
                     name='facebook-f',
                     purpose='semantic',
@@ -46,7 +46,7 @@
                 </a>
               {% endif %}
               {% if blog_author.linkedin %}
-                <a href="{{ blog_author.linkedin }}" target="_blank">
+                <a href="{{ blog_author.linkedin }}" target="_blank" rel="noopener">
                   {% icon
                     name='linkedin-in',
                     purpose='semantic',
@@ -57,7 +57,7 @@
                 </a>
               {% endif %}
               {% if blog_author.twitter %}
-                <a href="{{ blog_author.twitter }}" target="_blank">
+                <a href="{{ blog_author.twitter }}" target="_blank" rel="noopener">
                   {% icon
                     name='twitter',
                     purpose='semantic',


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds noopener to links that open in a new tab across the theme (https://web.dev/external-anchors-use-rel-noopener/). This was added to the blog author links (e.g. social/website), the social follow module, and the menu module (all other modules with links in the boilerplate theme already had this set up). This was flagged as an issue when running boilerplate through Google Lighthouse under "Best Practices". 

**Relevant links**

Related to the checklist in #181 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
