### PR TITLE
Remove duplicate ids

### DIFF
--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -55,10 +55,6 @@
   margin-top: 7px;
 }
 
-.header__logo--tablet {
-  display: none;
-}
-
 .header__logo--main {
   padding-top: 20px;
 }
@@ -253,14 +249,6 @@
 @media (max-width: 1150px) and (min-width: 767px) {
   .header__column {
     width: 100%;
-  }
-
-  .header__logo--main {
-    display: none;
-  }
-
-  .header__logo--tablet {
-    display: block;
   }
 }
 

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -28,7 +28,8 @@
         name='{{ social_icon }}',
         purpose='semantic',
         style='SOLID',
-        title='{{ item.accessibility.title }}'
+        title='{{ item.accessibility.title }}',
+        unique_in_loop=True
       %}
     </a>
   {% endfor %}

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -16,12 +16,6 @@
 
       {# Header navigation row one #}
       <div class="header__row-1">
-        <div class="header__logo header__logo--tablet">
-          {# This second logo module is for the tablet breakpoint,
-          so that the menu can wrap underneath the logo without breaking onto a new line.
-          It's hidden unless in a tablet breakpoint.  #}
-          {% module 'site_logo' path='@hubspot/logo' %}
-        </div>
         {% if content.translated_content|length %}
           <div class="header__language-switcher header--element">
             <div class="header__language-switcher--label">


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Removing duplicate ids where possible on the page. This was resolved in the for loop for the social follow module using `unique_in_loop=True` (more information here: https://developers.hubspot.com/docs/cms/hubl/for-loops#using-hubl-tags-in-loops) and was resolved for the header by removing the tablet logo and just using the main logo all the way through. 

**Relevant links**

Related to https://github.com/HubSpot/cms-theme-boilerplate/issues/181

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
