### PR TITLE
Fix mobile headings

### DIFF
--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -331,6 +331,7 @@
   .header__search--toggle.open:after,
   .header__language-switcher--toggle.open:after {
     display: block;
+    word-break: normal;
   }
 
   .header__navigation--toggle:after,

--- a/src/modules/card-section.module/module.css
+++ b/src/modules/card-section.module/module.css
@@ -13,34 +13,27 @@
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 0;
-  -ms-flex: 0 1 250px;
-  flex: 0 1 250px;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   margin: 1rem 0;
-  width: 20%;
+  max-width: 100%;
+  width: 250px;
 }
 
 .card__image {
-  -webkit-box-flex: 0;
-  -ms-flex: 0 0 30px;
-  flex: 0 0 30px;
+  height: auto;
   max-width: 250px;
   padding: 10px;
   width: 100%;
 }
 
 .card__text {
-  -webkit-box-flex: 1;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   padding: 0 1rem;
   text-align: center;
-  word-break: break-word;
+  width: 100%;
 }


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Fixes a bug introduced in (https://github.com/HubSpot/cms-theme-boilerplate/pull/187). It looks like the different mobile menu titles (using pseudo elements) weren't getting their default width because of the word-break that was set globally. Setting `word-break: normal;` for these elements should resolve that issue. 

<img width="91" alt="Screen Shot 2020-06-24 at 2 49 29 PM" src="https://user-images.githubusercontent.com/22665237/85615539-65249780-b62a-11ea-8f4a-ab576954b562.png">

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.