### PR TITLE
Adding lang specific classes to menu items

### DIFF
--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -3,7 +3,7 @@
 {% macro defaultItemClasses() %}
  {{
   {
-    'class': 'no-submenu menu-item'
+    'class': 'no-submenu menu-item hs-skip-lang-url-rewrite'
   }|xmlattr
  }}
 {% endmacro %}
@@ -13,7 +13,7 @@
 {% macro childClasses() %}
  {{
   {
-    'class': 'has-submenu menu-item'
+    'class': 'has-submenu menu-item hs-skip-lang-url-rewrite'
   }|xmlattr
  }}
 {% endmacro %}


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adding the class name of `hs-skip-lang-url-rewrite` to menu items in the custom menu module [per the instructions in the last bullet point here](https://developers.hubspot.com/docs/cms/features/multi-language-content#what-hubspot-does-automatically) to remove language translation query at the end of URLs in the menu module. 

**Relevant links**

Example page: http://jrosa-102019231.hs-sitesqa.com/-temporary-slug-89d8f767-0d8e-461a-abcc-f099f31bb597?hs_preview=JRNqHsFh-4278306148

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech 
CC: @LisleBuckley this is likely a change you'll want to add to your boilerplate 
