### PR TITLE
Reducing min-height in grid

### DIFF
--- a/src/css/objects/_layout.css
+++ b/src/css/objects/_layout.css
@@ -18,7 +18,7 @@
     display: block;
     float: left;
     width: 100%;
-    min-height: 28px;
+    min-height: 1px;
     margin-left: 2.127659574%;
     *margin-left: 2.0744680846382977%;
     -webkit-box-sizing: border-box;
@@ -136,7 +136,7 @@
         display: block;
         float: left;
         width: 100%;
-        min-height: 28px;
+        min-height: 1px;
         margin-left: 2.762430939%;
         *margin-left: 2.709239449638298%;
         -webkit-box-sizing: border-box;
@@ -229,7 +229,7 @@
         display: block;
         float: left;
         width: 100%;
-        min-height: 28px;
+        min-height: 1px;
         margin-left: 2.564102564%;
         *margin-left: 2.510911074638298%;
         -webkit-box-sizing: border-box;


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This pull request reduces the min-height that is set on elements with the class of "span" within an element with a class of "row-fluid". This looks like it was pulled over from Bootstrap 2 but isn't needed for a module drop zone in the editor. This should resolve an issue that was reported where a developer had multiple DND areas on a template but in the editor a user removed all modules in one of the DND areas, thus was getting a weird 28px gap that they couldn't remove. 

**Relevant links**

Example of page: 
<img width="1252" alt="Screen Shot 2020-10-22 at 1 35 35 PM" src="https://user-images.githubusercontent.com/22665237/96909081-8330c600-146b-11eb-8e84-fe8fc05e17cb.png">

Example in editor: 
<img width="892" alt="Screen Shot 2020-10-22 at 1 35 43 PM" src="https://user-images.githubusercontent.com/22665237/96909093-86c44d00-146b-11eb-8814-7d3536c607db.png">

Resolves #239 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @ajlaporte @TheWebTech
