### PR TITLE
Swap background images for images and improve accessibility/performance for blog images

### DIFF
--- a/src/css/templates/_blog.css
+++ b/src/css/templates/_blog.css
@@ -33,12 +33,10 @@
 /* Blog header - author listing */
 
 .blog-header__author-avatar {
-  background-position: center center;
-  background-size: cover;
-  background-repeat: no-repeat;
   border-radius: 50%;
   box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.15);
-  height: 200px;
+  display: block;
+  height: auto;
   margin: 0 auto 1.5rem;
   width: 200px;
 }
@@ -140,30 +138,12 @@
 }
 
 .blog-index__post-image {
-  display: block;
-  background-image: url('https://cdn2.hubspot.net/hubfs/6326501/boilerplate/grayscale-mountain.png');
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  padding-bottom: 63%;
+  height: auto;
+  max-width: 100%;
 }
 
 @media screen and (min-width: 768px) {
-  .blog-index__post-image--large {
-    -webkit-box-flex: 1;
-    -ms-flex: 1 1 100%;
-    flex: 1 1 100%;
-    padding-bottom: 0;
-  }
-
-  .blog-index__post-content--large {
-    -webkit-box-flex: 1;
-    -ms-flex: 1 1 100%;
-    flex: 1 1 100%;
-    padding-left: 2rem;
-  }
-
-  .blog-index__post-image--large {
+  .blog-index__post-image-wrapper--large {
     -webkit-box-flex: 1;
     -ms-flex: 1 1 48%;
     flex: 1 1 48%;
@@ -198,11 +178,6 @@
 
 .blog-index__post-content a {
   color: #494A52;
-}
-
-.blog-index__post img {
-  height: auto;
-  max-width: 100%;
 }
 
 /* Blog pagination */
@@ -374,10 +349,8 @@
 }
 
 .blog-recent-posts__image {
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  padding-bottom: 63%;
+  height: auto;
+  max-width: 100%;
 }
 
 .blog-recent-posts__title {

--- a/src/css/templates/_blog.css
+++ b/src/css/templates/_blog.css
@@ -301,17 +301,17 @@
 
 /* Blog related posts */
 
-.blog-recent-posts {
+.blog-related-posts {
   background-color: #F8FAFC;
   margin-top: 3rem;
   padding: 2rem 0;
 }
 
-.blog-recent-posts h2 {
+.blog-related-posts h2 {
   text-align: center;
 }
 
-.blog-recent-posts__list {
+.blog-related-posts__list {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -319,7 +319,7 @@
   flex-wrap: wrap;
 }
 
-.blog-recent-posts__post {
+.blog-related-posts__post {
   color: #494A52;
   display: block;
   -webkit-box-flex: 0;
@@ -329,7 +329,7 @@
 }
 
 @media screen and (min-width: 768px) {
-  .blog-recent-posts__post {
+  .blog-related-posts__post {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 calc(100%/2);
     flex: 0 0 calc(100%/2);
@@ -337,24 +337,24 @@
 }
 
 @media screen and (min-width: 1000px) {
-  .blog-recent-posts__post {
+  .blog-related-posts__post {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 calc(100%/3);
     flex: 0 0 calc(100%/3);
   }
 }
 
-.blog-recent-posts__post:hover {
-  text-decoration: none;
-}
-
-.blog-recent-posts__image {
+.blog-related-posts__image {
   height: auto;
   max-width: 100%;
 }
 
-.blog-recent-posts__title {
+.blog-related-posts__title {
   margin: 1rem 0 0.5rem;
+}
+
+.blog-related-posts__title a {
+  color: #494a52;
 }
 
 /* Blog comments */

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -107,9 +107,9 @@
         {% for content in contents %}
           {# On the blog listing page, the first post will be featured above older posts #}
           {% if (loop.first && current_page_num == 1 && !topic) %}
-            <article class="blog-index__post blog-index__post--large">
+            <article class="blog-index__post blog-index__post--large" aria-label="Blog post summary: {{ content.name }}">
               {% if content.featured_image and group.use_featured_image_in_summary %}
-                <a class="blog-index__post-image-wrapper blog-index__post-image-wrapper--large" href="{{ content.absolute_url }}" aria-label="Read {{ content.name }}">
+                <a class="blog-index__post-image-wrapper blog-index__post-image-wrapper--large" href="{{ content.absolute_url }}" aria-label="{% if content.featured_image_alt_text %}Featured image: {{ content.featured_image_alt_text }} - {% endif %}Read full post: {{ content.name }}">
                   <img class="blog-index__post-image" src="{{ content.featured_image }}" width="596" alt="{% if content.featured_image_alt_text %}{{ content.featured_image_alt_text }}{% endif %}">
                 </a>
               {% endif %}
@@ -121,9 +121,9 @@
               </div>
             </article>
           {% else %}
-            <article class="blog-index__post blog-index__post--small">
+            <article class="blog-index__post blog-index__post--small" aria-label="Blog post summary: {{ content.name }}">
               {% if content.featured_image and group.use_featured_image_in_summary %}
-                <a href="{{ content.absolute_url }}" aria-label="Read {{ content.name }}">
+                <a href="{{ content.absolute_url }}" aria-label="{% if content.featured_image_alt_text %}Featured image: {{ content.featured_image_alt_text }} - {% endif %}Read full post: {{ content.name }}">
                   <img class="blog-index__post-image" src="{{ content.featured_image }}" width="365" loading="lazy" alt="{% if content.featured_image_alt_text %}{{ content.featured_image_alt_text }}{% endif %}">
                 </a>
               {% endif %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -110,7 +110,7 @@
             <article class="blog-index__post blog-index__post--large" aria-label="Blog post summary: {{ content.name }}">
               {% if content.featured_image and group.use_featured_image_in_summary %}
                 <a class="blog-index__post-image-wrapper blog-index__post-image-wrapper--large" href="{{ content.absolute_url }}" aria-label="{% if content.featured_image_alt_text %}Featured image: {{ content.featured_image_alt_text }} - {% endif %}Read full post: {{ content.name }}">
-                  <img class="blog-index__post-image" src="{{ content.featured_image }}" width="596" alt="{% if content.featured_image_alt_text %}{{ content.featured_image_alt_text }}{% endif %}">
+                  <img class="blog-index__post-image" src="{{ content.featured_image }}" width="596" alt="{{ content.featured_image_alt_text }}">
                 </a>
               {% endif %}
               <div class="blog-index__post-content  blog-index__post-content--large{% if !content.featured_image or !group.use_featured_image_in_summary %} blog-index__post-content--full-width{% endif %}">
@@ -124,7 +124,7 @@
             <article class="blog-index__post blog-index__post--small" aria-label="Blog post summary: {{ content.name }}">
               {% if content.featured_image and group.use_featured_image_in_summary %}
                 <a href="{{ content.absolute_url }}" aria-label="{% if content.featured_image_alt_text %}Featured image: {{ content.featured_image_alt_text }} - {% endif %}Read full post: {{ content.name }}">
-                  <img class="blog-index__post-image" src="{{ content.featured_image }}" width="365" loading="lazy" alt="{% if content.featured_image_alt_text %}{{ content.featured_image_alt_text }}{% endif %}">
+                  <img class="blog-index__post-image" src="{{ content.featured_image }}" width="365" loading="lazy" alt="{{ content.featured_image_alt_text }}">
                 </a>
               {% endif %}
               <div class="blog-index__post-content  blog-index__post-content--small">

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -15,7 +15,7 @@
       <div class="blog-header">
         <div class="blog-header__inner">
           {% if blog_author.avatar %}
-            <div class="blog-header__author-avatar" style="background-image: url('{{ blog_author.avatar }}');"></div>
+            <img class="blog-header__author-avatar" src="{{ blog_author.avatar }}" alt="{{ blog_author.display_name }}" width="200" loading="eager">
           {% endif %}
           <h1 class="blog-header__title">{{ blog_author.display_name }}</h1>
           {% if blog_author.bio %}
@@ -109,11 +109,8 @@
           {% if (loop.first && current_page_num == 1 && !topic) %}
             <article class="blog-index__post blog-index__post--large">
               {% if content.featured_image and group.use_featured_image_in_summary %}
-                <a class="blog-index__post-image blog-index__post-image--large"
-                  {% if content.featured_image %}
-                    style="background-image: url('{{ content.featured_image }}');"
-                  {% endif %}
-                  href="{{ content.absolute_url }}">
+                <a class="blog-index__post-image-wrapper blog-index__post-image-wrapper--large" href="{{ content.absolute_url }}" aria-label="Read {{ content.name }}">
+                  <img class="blog-index__post-image" src="{{ content.featured_image }}" width="596" alt="{% if content.featured_image_alt_text %}{{ content.featured_image_alt_text }}{% endif %}">
                 </a>
               {% endif %}
               <div class="blog-index__post-content  blog-index__post-content--large{% if !content.featured_image or !group.use_featured_image_in_summary %} blog-index__post-content--full-width{% endif %}">
@@ -126,7 +123,8 @@
           {% else %}
             <article class="blog-index__post blog-index__post--small">
               {% if content.featured_image and group.use_featured_image_in_summary %}
-                <a class="blog-index__post-image blog-index__post-image--small" style="background-image: url('{{ content.featured_image }}');" href="{{ content.absolute_url }}">
+                <a href="{{ content.absolute_url }}" aria-label="Read {{ content.name }}">
+                  <img class="blog-index__post-image" src="{{ content.featured_image }}" width="365" loading="lazy" alt="{% if content.featured_image_alt_text %}{{ content.featured_image_alt_text }}{% endif %}">
                 </a>
               {% endif %}
               <div class="blog-index__post-content  blog-index__post-content--small">

--- a/src/templates/blog-post.html
+++ b/src/templates/blog-post.html
@@ -70,7 +70,7 @@
       <article class="blog-related-posts__post" aria-label="Blog post summary: {{ post.name }}">
         {% if post.featured_image %}
           <a class="blog-related-posts__post-image-wrapper" href="{{ post.absolute_url }}" aria-label="{% if post.featured_image_alt_text %} Featured image: {{ post.featured_image_alt_text }} - {% endif %}Read full post: {{ post.name }}">
-            <img class="blog-related-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{% if post.featured_image_alt_text %}{{ post.featured_image_alt_text }}{% endif %}">
+            <img class="blog-related-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{{ post.featured_image_alt_text }}">
           </a>
         {% endif %}
         <div class="blog-related-posts__content">

--- a/src/templates/blog-post.html
+++ b/src/templates/blog-post.html
@@ -68,8 +68,8 @@
       gets passed to the 'related_blog_posts' tag below #}
     {% macro recent_post(post) %}
       <a href="{{ post.absolute_url }}" class="blog-recent-posts__post">
-        <div class="blog-recent-posts__image" style="background-image: url('{{ post.featuredImage }}');"></div>
-        <h3 class="blog-recent-posts__title">{{post.title}}</h3>
+        <img class="blog-recent-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{{ post.featured_image_alt_text }}">
+        <h3 class="blog-recent-posts__title">{{ post.name }}</h3>
         {{ post.post_summary|truncatehtml(100) }}
       </a>
     {% endmacro %}

--- a/src/templates/blog-post.html
+++ b/src/templates/blog-post.html
@@ -67,17 +67,23 @@
     {# This macro is used to format each recent post card and
       gets passed to the 'related_blog_posts' tag below #}
     {% macro recent_post(post) %}
-      <a href="{{ post.absolute_url }}" class="blog-recent-posts__post">
-        <img class="blog-recent-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{{ post.featured_image_alt_text }}">
-        <h3 class="blog-recent-posts__title">{{ post.name }}</h3>
-        {{ post.post_summary|truncatehtml(100) }}
-      </a>
+      <article class="blog-related-posts__post" aria-label="Blog post summary: {{ post.name }}">
+        {% if post.featured_image %}
+          <a class="blog-related-posts__post-image-wrapper" href="{{ post.absolute_url }}" aria-label="{% if post.featured_image_alt_text %} Featured image: {{ post.featured_image_alt_text }} - {% endif %}Read full post: {{ post.name }}">
+            <img class="blog-related-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{% if post.featured_image_alt_text %}{{ post.featured_image_alt_text }}{% endif %}">
+          </a>
+        {% endif %}
+        <div class="blog-related-posts__content">
+          <h3 class="blog-related-posts__title"><a href="{{ post.absolute_url }}">{{ post.name }}</a></h3>
+          {{ post.post_summary|truncatehtml(100) }}
+        </div>
+      </article>
     {% endmacro %}
 
-    <div class="blog-recent-posts">
+    <section class="blog-related-posts">
       <div class="content-wrapper">
         <h2>Read On</h2>
-        <div class="blog-recent-posts__list">
+        <div class="blog-related-posts__list">
           {% related_blog_posts
             limit=3,
             no_wrapper=True,
@@ -85,7 +91,7 @@
           %}
         </div>
       </div>
-    </div>
+    </section>
     {# End recent posts listing #}
 
   </div>


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

In an effort to improve the out of the box accessibility and performance of the boilerplate blog, this PR does the following: 
- Swaps background images for images
  - This allowed us to take advantage of the [native `loading` attribute](https://web.dev/browser-level-image-lazy-loading/)
  - This allowed us to use a `width` attribute which should [enable automatic image resizing](https://developers.hubspot.com/docs/cms/developer-reference/cdn#image-compression-optimization-and-automatic-image-resizing)
  - This allowed us to include an optional alt text for listing images
  - This allowed us to include alt text for the author image on the author listing page
- Adds aria-label for links around listing images so there is discernible link text 

**Additional comments/questions/considerations:**
- I set the blog author image on the blog listing page to `loading="eager"` as that will load above the fold on most devices (e.g. image of author at top of page [here](http://jrosa-102019231.hs-sitesqa.com/blog/author/sample-hubspot-user))
- Should I set the first featured image to have a certain `loading` value? In a lot of cases I would imagine it would be above the fold and it could likely be the largest contentful paint element in some scenarios depending on the image being used/other elements on the template. I was considering setting that particular image to have a `loading` value of `eager` but wanted to get other's thoughts first. 
- Moving away from the background image concept means that all images won't be the exact same size in the grid. This can be interpreted as a positive design change (someone may not want their images getting cut off) or a negative design change (the grid is less clean unless a user uses featured images with the same proportions). Any thoughts on this change? We could look at alternative options like `object-fit` if we want to have similarly sized featured images in the listing. 

**Relevant links**

Blog example with fixes: http://jrosa-102019231.hs-sitesqa.com/blog

Page performance of boilerplate blog: https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fboilerplate.hubspotcms.com%2Fblog&tab=desktop
Page performance of boilerplate blog with fixes/test example: https://developers.google.com/speed/pagespeed/insights/?url=http%3A%2F%2Fjrosa-102019231.hs-sitesqa.com%2Fblog&tab=desktop

The current boilerplate blog is scoring around 10 points lower on mobile when testing on my end in comparison to the test example (the original boilerplate blog has a menu whereas the test example doesn't currently). The text example is also using larger images/multiple different images. 

Resolves #226 
Resolves #234 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
