### PR TITLE
Update links to prevent tabnabbing vulnerability

### DIFF
--- a/src/modules/customizable-button.module/fields.json
+++ b/src/modules/customizable-button.module/fields.json
@@ -1,12 +1,12 @@
 [
   {
-    "label": "",
+    "label": "Button link",
     "name": "link",
     "type": "link",
     "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
     "default": {
       "url": {
-        "href": "www.hubspot.com",
+        "href": "",
         "type": "EXTERNAL"
       },
       "no_follow": false,

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -1,20 +1,18 @@
-{% macro setLinkAttributes(field) %}
-  {% set href = (field.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ field.url.href : field.url.href %}
-  {% if href %}
-    {{ {'href': '{{ href }}'}|xmlattr }}
-  {% endif %}
+{% set href = module.link.url.href %}
+{% if module.link.url.type is equalto "EMAIL_ADDRESS" %}
+  {% set href = "mailto:" + href %}
+{% endif %}
+{% set rel = [] %}
+{% if module.link.no_follow %}
+  {% do rel.append("nofollow") %}
+{% endif %}
+{% if module.link.open_in_new_tab %}
+  {% do rel.append("noopener") %}
+{% endif %}
 
-  {% if field.open_in_new_tab and field.no_follow %}
-    {{ {'rel': 'noopener nofollow'}|xmlattr }}
-    {{ {'target': '_blank'}|xmlattr }}
-  {% elif field.open_in_new_tab %}
-    {{ {'rel': 'noopener'}|xmlattr }}
-    {{ {'target': '_blank'}|xmlattr }}
-  {% elif field.no_follow %}
-    {{ {'rel': 'nofollow'}|xmlattr }}
-  {% endif %}
-{% endmacro %}
-
-<a class="button" {{ setLinkAttributes(module.link) }}>
+<a class="button" href="{{ href }}"
+{% if module.link.open_in_new_tab %}target="_blank"{% endif %}
+{% if rel %}rel="{{ rel|join(' ') }}"{% endif %}
+>
   {{ module.button_text }}
 </a>

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -9,22 +9,17 @@
   }
 -%}
 
-{% macro setLinkAttributes(field) %}
-  {% set href = (field.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ field.url.href : field.url.href %}
-  {% if href %}
-    {{ {'href': '{{ href }}'}|xmlattr }}
-  {% endif %}
-
-  {% if field.open_in_new_tab and field.no_follow %}
-    {{ {'rel': 'noopener nofollow'}|xmlattr }}
-    {{ {'target': '_blank'}|xmlattr }}
-  {% elif field.open_in_new_tab %}
-    {{ {'rel': 'noopener'}|xmlattr }}
-    {{ {'target': '_blank'}|xmlattr }}
-  {% elif field.no_follow %}
-    {{ {'rel': 'nofollow'}|xmlattr }}
-  {% endif %}
-{% endmacro %}
+{% set href = module.button_link.url.href %}
+{% if module.button_link.url.type is equalto "EMAIL_ADDRESS" %}
+	{% set href = "mailto:" + href %}
+{% endif %}
+{% set rel = [] %}
+{% if module.button_link.no_follow %}
+	{% do rel.append("nofollow") %}
+{% endif %}
+{% if module.button_link.open_in_new_tab %}
+	{% do rel.append("noopener") %}
+{% endif %}
 
 <div class="card card--pricing">
   {% if module.tier and module.description %}
@@ -54,7 +49,11 @@
     </ul>
     <hr>
     <h3 class="card__heading">{{ module.price }}</h3>
-    <a class="button" {{ setLinkAttributes(module.button_link) }} style="{{ inlineDynamicButtonStyles(buttonStyles) }}">
+    <a class="button"
+    style="{{ inlineDynamicButtonStyles(buttonStyles) }}"
+    href="{{ href }}"
+    {% if module.button_link.open_in_new_tab %}target="_blank"{% endif %}
+    {% if rel %}rel="{{ rel|join(" ") }}"{% endif %}>
       {{ module.button_text }}
     </a>
   </div>

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -1,28 +1,26 @@
-{% macro setLinkAttributes(field) %}
-  {% set href = (field.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ field.url.href : field.url.href %}
-  {% if href %}
-    {{ {'href': '{{ href }}'}|xmlattr }}
-  {% endif %}
-
-  {% if field.open_in_new_tab and field.no_follow %}
-    {{ {'rel': 'noopener nofollow'}|xmlattr }}
-    {{ {'target': '_blank'}|xmlattr }}
-  {% elif field.open_in_new_tab %}
-    {{ {'rel': 'noopener'}|xmlattr }}
-    {{ {'target': '_blank'}|xmlattr }}
-  {% elif field.no_follow %}
-    {{ {'rel': 'nofollow'}|xmlattr }}
-  {% endif %}
-{% endmacro %}
-
 <div class="social-links">
   {% for item in module.social_links %}
+    {% set href = item.social_link.url.href %}
+    {% if item.social_link.url.type is equalto "EMAIL_ADDRESS" %}
+      {% set href = "mailto:" + href %}
+    {% endif %}
+    {% set rel = [] %}
+    {% if module.link_field.no_follow %}
+      {% do rel.append("nofollow") %}
+    {% endif %}
+    {% if module.link_field.open_in_new_tab %}
+      {% do rel.append("noopener") %}
+    {% endif %}
+
     {% if item.social_account != 'custom_icon' %}
       {% set social_icon = item.social_account %}
     {% else %}
       {% set social_icon = item.custom_icon.name %}
     {% endif %}
-    <a class="social-links__link" {{ setLinkAttributes(item.social_link) }}>
+
+    <a class="social-links__link" href="{{ href }}"
+		{% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
+		{% if rel %}rel="{{ rel|join(" ") }}"{% endif %}>
       {% icon
         extra_classes='social-links__icon',
         name='{{ social_icon }}',

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -19,8 +19,8 @@
     {% endif %}
 
     <a class="social-links__link" href="{{ href }}"
-		{% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
-		{% if rel %}rel="{{ rel|join(' ') }}"{% endif %}>
+    {% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
+    {% if rel %}rel="{{ rel|join(' ') }}"{% endif %}>
       {% icon
         extra_classes='social-links__icon',
         name='{{ social_icon }}',

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -5,10 +5,10 @@
       {% set href = "mailto:" + href %}
     {% endif %}
     {% set rel = [] %}
-    {% if module.link_field.no_follow %}
+    {% if item.social_link.no_follow %}
       {% do rel.append("nofollow") %}
     {% endif %}
-    {% if module.link_field.open_in_new_tab %}
+    {% if item.social_link.open_in_new_tab %}
       {% do rel.append("noopener") %}
     {% endif %}
 
@@ -20,7 +20,7 @@
 
     <a class="social-links__link" href="{{ href }}"
 		{% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
-		{% if rel %}rel="{{ rel|join(" ") }}"{% endif %}>
+		{% if rel %}rel="{{ rel|join(' ') }}"{% endif %}>
       {% icon
         extra_classes='social-links__icon',
         name='{{ social_icon }}',


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

- Checked through boilerplate for tabnabbing vulnerability. All modules within boilerplate were already working for this. I just swapped out the macro we were using for the new default snippet for link fields that includes the fix for adding `rel='noopener'` if a link is opened in a new window. 
- Added a label for the button link field for the button module.
- Removed HubSpot as the default link for the button module.

**Relevant links**

Resolves #233 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
