### PR TITLE
Add a QA test template to boilerplate

### DIFF
--- a/src/templates/qa-test.html
+++ b/src/templates/qa-test.html
@@ -2,7 +2,6 @@
   templateType: page
   isAvailableForNewContent: false
   label: QA test
-  screenshotPath: ../images/template-previews/hubdb.png
 -->
 {% extends './layouts/base.html' %}
 

--- a/src/templates/qa-test.html
+++ b/src/templates/qa-test.html
@@ -1,0 +1,209 @@
+<!--
+  templateType: page
+  isAvailableForNewContent: false
+  label: QA test
+  screenshotPath: ../images/template-previews/hubdb.png
+-->
+{% extends './layouts/base.html' %}
+
+{% block body %}
+<main class="body-container-wrapper">
+  {% dnd_area 'dnd_area' class='body-container body-container--qa-test', label='Main section' %}
+
+    {# Typography section #}
+    {% dnd_section %}
+      {% dnd_column %}
+        {% dnd_row %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h2>Typography</h2>
+              <hr>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h1>Heading 1</h1>
+              <h2>Heading 2</h2>
+              <h3>Heading 3</h3>
+              <h4>Heading 4</h4>
+              <h5>Heading 5</h5>
+              <h6>Heading 6</h6>
+              <p>Lorem ipsum dolor sit amet, consectetur <em>adipiscing elit</em>. Duis porttitor, quam vel <strong>dignissim</strong> tincidunt, odio libero porta ligula, vitae fermentum lacus libero vel risus. Aenean pulvinar nisl et <a href="#">vestibulum commodo</a>. Quisque euismod tempus dignissim. Quisque dictum luctus velit, eu viverra urna tristique non. Vivamus at dolor tellus. Cras congue sapien non turpis dapibus, et vestibulum ante ultrices. Mauris eu nisi non sapien fermentum fermentum in eu odio. Fusce congue elit et tortor sagittis, sit amet auctor risus sagittis.</p>
+              <p>This line contains <sub>subscript</sub> text.</p>
+              <p>This line contains <sup>superscript</sup> text.</p>
+              <p>This line contains <code>code</code>.</p>
+              <p>This line contains <small>small</small> text.</p>
+              <p>This line contains <mark>highlighted</mark> text</p>
+              <pre><code>.preformatted-code { background-color: #FFF; }</code></pre>
+              <ul>
+              <li>Unordered list item</li>
+              <li>Unordered list item</li>
+              <li>Unordered list item</li>
+              <li>Unordered list item</li>
+              </ul>
+              <ol>
+              <li>First ordered list item</li>
+              <li>Second ordered list item</li>
+              <li>Third ordered list item</li>
+              <li>Fourth ordered list item</li>
+              </ol>
+              <blockquote>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis porttitor, quam vel dignissim tincidunt, odio libero porta ligula, vitae fermentum lacus libero vel risus. Aenean pulvinar nisl et vestibulum commodo. Quisque euismod tempus dignissim.</blockquote>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Header column one</th>
+                    <th>Header column two</th>
+                    <th>Header column three</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Row one column one</td>
+                    <td>Row one column two</td>
+                    <td>Row one column three</td>
+                  </tr>
+                  <tr>
+                    <td>Row two column one</td>
+                    <td>Row two column two</td>
+                    <td>Row two column three</td>
+                  </tr>
+                  <tr>
+                    <td>Row three column one</td>
+                    <td>Row three column two</td>
+                    <td>Row three column three</td>
+                  </tr>
+                  <tr>
+                    <td>Row four column one</td>
+                    <td>Row four column two</td>
+                    <td>Row four column three</td>
+                  </tr>
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td>Footer column one</td>
+                    <td>Footer column two</td>
+                    <td>Footer column three</td>
+                  </tr>
+                </tfoot>
+              </table>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+    {# End typography section #}
+
+    {# Forms section #}
+    {% dnd_section %}
+      {% dnd_column %}
+        {% dnd_row %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h2>Forms</h2>
+              <hr>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='@hubspot/form' %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+    {# End forms section #}
+
+    {# Theme modules section #}
+    {% dnd_section %}
+      {% dnd_column %}
+        {% dnd_row %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h2>Theme modules</h2>
+              <hr>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row
+          margin={
+            'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h3>Card section</h3>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='../modules/card-section' %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row
+          margin={
+            'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h3>Customizable button</h3>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='../modules/customizable-button' %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row
+          margin={
+            'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h3>Menu section</h3>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='../modules/menu-section' %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row
+          margin={
+            'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h3>Pricing card</h3>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='../modules/pricing-card' %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row
+          margin={
+            'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/rich_text' %}
+            {% module_attribute 'html' %}
+              <h3>Social follow</h3>
+            {% end_module_attribute %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path='../modules/social-follow' %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+    {# End theme modules section #}
+
+  {% end_dnd_area %}
+</main>
+{% endblock body %}

--- a/src/templates/qa-test.html
+++ b/src/templates/qa-test.html
@@ -105,10 +105,61 @@
             {% end_module_attribute %}
           {% end_dnd_module %}
         {% end_dnd_row %}
-        {% dnd_row %}
+
+        {# One column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
           {% dnd_module path='@hubspot/form' %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+        {# End one column #}
+
+        {# Two column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/form',
+            offset=0,
+            width=6
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='@hubspot/form',
+            offset=6,
+            width=6
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End two column #}
+
+        {# Three column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='@hubspot/form',
+            offset=0,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='@hubspot/form',
+            offset=4,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='@hubspot/form',
+            offset=8,
+            width=4
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End three column #}
+
       {% end_dnd_column %}
     {% end_dnd_section %}
     {# End forms section #}
@@ -124,6 +175,8 @@
             {% end_module_attribute %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+
+        {# Card section module #}
         {% dnd_row
           margin={
             'top': 35
@@ -135,10 +188,64 @@
             {% end_module_attribute %}
           {% end_dnd_module %}
         {% end_dnd_row %}
-        {% dnd_row %}
+
+        {# One column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
           {% dnd_module path='../modules/card-section' %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+        {# End one column #}
+
+        {# Two column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/card-section',
+            offset=0,
+            width=6
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/card-section',
+            offset=6,
+            width=6
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End two column #}
+
+        {# Three column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/card-section',
+            offset=0,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/card-section',
+            offset=4,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/card-section',
+            offset=8,
+            width=4
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End three column #}
+
+        {# End card section module #}
+
+        {# Customizable button module #}
         {% dnd_row
           margin={
             'top': 35
@@ -150,10 +257,64 @@
             {% end_module_attribute %}
           {% end_dnd_module %}
         {% end_dnd_row %}
-        {% dnd_row %}
+
+        {# One column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
           {% dnd_module path='../modules/customizable-button' %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+        {# End one column #}
+
+        {# Two column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/customizable-button',
+            offset=0,
+            width=6
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/customizable-button',
+            offset=6,
+            width=6
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End two column #}
+
+        {# Three column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/customizable-button',
+            offset=0,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/customizable-button',
+            offset=4,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/customizable-button',
+            offset=8,
+            width=4
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End three column #}
+
+        {# End customizable button module #}
+
+        {# Menu section module #}
         {% dnd_row
           margin={
             'top': 35
@@ -169,6 +330,9 @@
           {% dnd_module path='../modules/menu-section' %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+        {# End menu section module #}
+
+        {# Pricing card module #}
         {% dnd_row
           margin={
             'top': 35
@@ -180,10 +344,64 @@
             {% end_module_attribute %}
           {% end_dnd_module %}
         {% end_dnd_row %}
-        {% dnd_row %}
+
+        {# One column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
           {% dnd_module path='../modules/pricing-card' %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+        {# End one column #}
+
+        {# Two column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/pricing-card',
+            offset=0,
+            width=6
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/pricing-card',
+            offset=6,
+            width=6
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End two column #}
+
+        {# Three column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/pricing-card',
+            offset=0,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/pricing-card',
+            offset=4,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/pricing-card',
+            offset=8,
+            width=4
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End three column #}
+
+        {# End pricing card module #}
+
+        {# Social follow module #}
         {% dnd_row
           margin={
             'top': 35
@@ -195,14 +413,64 @@
             {% end_module_attribute %}
           {% end_dnd_module %}
         {% end_dnd_row %}
-        {% dnd_row %}
+        {# One column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
           {% dnd_module path='../modules/social-follow' %}
           {% end_dnd_module %}
         {% end_dnd_row %}
+        {# End one column #}
+
+        {# Two column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/social-follow',
+            offset=0,
+            width=6
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/social-follow',
+            offset=6,
+            width=6
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End two column #}
+
+        {# Three column #}
+        {% dnd_row
+          padding={
+          'top': 35
+          }
+        %}
+          {% dnd_module path='../modules/social-follow',
+            offset=0,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/social-follow',
+            offset=4,
+            width=4
+          %}
+          {% end_dnd_module %}
+          {% dnd_module path='../modules/social-follow',
+            offset=8,
+            width=4
+          %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {# End three column #}
+
+        {# End social follow module #}
+
       {% end_dnd_column %}
     {% end_dnd_section %}
-    {# End theme modules section #}
-
   {% end_dnd_area %}
 </main>
 {% endblock body %}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [X] New feature (change which adds new functionality)

**Description**

This had come up on a couple of calls with developers where it would be nice to have an out of the box test template that makes it easy to test things like typography, forms, etc. to ensure that everything is accounted for when doing QA. I've started off with a typography section, a forms section, and a theme module section for now but this can be easily added to or modified down the road based on feedback. By default it is set to `false` for `isAvailableForNewContent` so that this isn't accidentally used for an actual page. The idea would be that a developer would use this while developing a new theme but would delete it prior to finalizing the production/live environment (e.g. marketplace or live site). 

**Relevant links**

[Example link](https://preview.hs-sitesqa.com/_hcms/preview/template/multi?domain=undefined&hs_preview_key=fePF-ajdD4yw74LlMwayKw&portalId=102019231&tc_deviceCategory=undefined&template_file_path=boilerplate-theme/templates/qa-test.html&updated=1603812037469) - there is an issue with one of the theme module's default image (will address that separately from this issue). 
Resolves #212 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
@TheWebTech @ajlaporte @gcorne 
