### PR TITLE
Update language conditional to account for blog listing page

### DIFF
--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -16,7 +16,7 @@
 
       {# Header navigation row one #}
       <div class="header__row-1">
-        {% if content.translated_content|length %}
+        {% if content.translated_content|length || group.translations %}
           <div class="header__language-switcher header--element">
             <div class="header__language-switcher--label">
               {% module 'language-switcher' path='@hubspot/language_switcher',


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

We use a conditional in the `header.html` file that shows/hides the language toggle depending on if the current page has a translation. This works for pages and posts but didn't account for blog listing pages. This update adds to the original conditional to also account for blog listing pages. 

**Relevant links**

Resolves #253 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
