### PR TITLE
Fix blog markup

### DIFF
--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -10,16 +10,18 @@
 <main class="body-container-wrapper">
   <div class="body-container body-container--blog-index">
 
-    {# Blog author listing #}
-    {% if blog_author %}
-      <div class="blog-header">
-        <div class="blog-header__inner">
+    {# Blog header #}
+    <div class="blog-header">
+      <div class="blog-header__inner">
+
+        {# Blog author listing header #}
+        {% if blog_author %}
           {% if blog_author.avatar %}
             <img class="blog-header__author-avatar" src="{{ blog_author.avatar }}" alt="{{ blog_author.display_name }}" width="200" loading="eager">
           {% endif %}
           <h1 class="blog-header__title">{{ blog_author.display_name }}</h1>
           {% if blog_author.bio %}
-            <h4 class="blog-header__subtitle">{{ blog_author.bio }}</h4>
+            <p class="blog-header__subtitle">{{ blog_author.bio }}</p>
           {% endif %}
           {% if blog_author.has_social_profiles %}
             <div class="blog-header__author-social-links">
@@ -69,33 +71,27 @@
               {% endif %}
             </div>
           {% endif %}
-        </div>
-      </div>
-    {% elif tag %}
-    {# End blog author listing #}
+        {% elif tag %}
+        {# End blog author listing header #}
 
-    {# Blog tag listing #}
-      <div class="blog-header">
-        <div class="blog-header__inner">
+        {# Blog tag listing header #}
           <h1 class="blog-header__title">Posts about {{ page_meta.html_title|split(' | ')|last }}</h1>
-        </div>
-      </div>
-    {% else %}
-    {# End blog tag listing #}
+        {% else %}
+        {# End blog tag listing header #}
 
-    {# Blog header #}
-      <div class="blog-header">
-        <div class="blog-header__inner">
+        {# Blog listing header #}
           <h1 class="blog-header__title">{{ group.public_title }}</h1>
-          <h4 class="blog-header__subtitle">{{ group.description }}</h4>
+          <p class="blog-header__subtitle">{{ group.description }}</p>
           <div class="blog-header__form">
             {% module "blog_subscribe_form" path="@hubspot/blog_subscribe",
               title=""
             %}
           </div>
-        </div>
+        {% endif %}
+        {# End blog listing header #}
+
       </div>
-    {% endif %}
+    </div>
     {# End blog header #}
 
     <div class="content-wrapper">

--- a/src/templates/blog-post.html
+++ b/src/templates/blog-post.html
@@ -10,20 +10,6 @@
 <main class="body-container-wrapper">
   <div class="body-container body-container--blog-post">
 
-    {# Blog header #}
-    <div class="blog-header">
-      <div class="blog-header__inner">
-        <h2 class="blog-header__title">{{ group.public_title }}</h2>
-        <h4 class="blog-header__subtitle">{{ group.description }}</h4>
-        <div class="blog-header__form">
-          {% module "blog_subscribe_form" path="@hubspot/blog_subscribe",
-            title=""
-          %}
-        </div>
-      </div>
-    </div>
-    {# End blog header #}
-
     {# Blog post #}
     <div class="content-wrapper">
       <article class="blog-post">


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

- Changed h4 that was under the h1 in the blog header on the listing template to a paragraph tag (did this for the author listing page as well). 
- Rearranged code for blog header on listing pages a bit. Everything stays the same - I just realized we were repeating a few lines within a conditional and it would be DRYer to pull that out of the conditional. 
- Removed the blog header on the post template. That header had an h2 and an h4 and the post title (the h1) was set below the header. Removing this ensures that the blog headers stay in sequential order. 

**Relevant links**

[Example blog listing/post](http://jrosa-102019231.hs-sitesqa.com/blog)
Resolves #225 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**

CC: @TheWebTech this doesn't impact the changes you were working on [here](https://github.com/HubSpot/cms-theme-boilerplate/pull/238) so far but just wanted to keep you in the loop. 
