### PR TITLE
Adding a couple of mobile padding examples

### DIFF
--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -118,20 +118,36 @@
       },
       max_width=700,
       padding={
-        'top': 140,
-        'right': 20,
-        'bottom': 160,
-        'left': 20
+        'default': {
+          'top': 140,
+          'right': 20,
+          'bottom': 160,
+          'left': 20
+        },
+        'mobile': {
+          'top': 80,
+          'right': 20,
+          'bottom': 80,
+          'left': 20
+        }
       },
       vertical_alignment='MIDDLE'
     %}
       {% dnd_column %}
         {% dnd_row
           padding={
-            'top': 0,
-            'right': 0,
-            'bottom': 40,
-            'left': 0
+            'default': {
+              'top': 0,
+              'right': 0,
+              'bottom': 40,
+              'left': 0
+            },
+            'mobile': {
+              'top': 0,
+              'right': 0,
+              'bottom': 0,
+              'left': 0
+            }
           }
         %}
           {% dnd_module path='@hubspot/rich_text',


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [X] New feature (change which adds new functionality)

**Description**

Fulfills the request to add a couple of examples of mobile editing in the boilerplate [via conversation here](https://github.com/HubSpot/cms-theme-boilerplate/pull/246). There weren't a ton of locations that would work for this but a couple areas in the home page were already using padding that could be reduced on mobile. This should provide a couple of examples for now and we can work to add more in in the future. 

**Relevant links**

Resolves #247 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
