### PR TITLE
Remove aria-hidden

### DIFF
--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -71,7 +71,7 @@
 
 {% macro renderNavigation(menuTree) %}
   {% set level = level + 1 %}
-  <ul class="submenu level-{{ level }}" aria-hidden="{{ level != 1 }}">
+  <ul class="submenu level-{{ level }}">
     {% for node in menuTree.children %}
       {{ link(node) }}
     {% endfor %}


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Removing `aria-hidden` from the child menus. `aria-hidden` is set to false but doesn't get changed to true when someone hovers/focuses on a parent item. We are choosing to remove this for the time being to alleviate that issue. We chose not to set the attribute based on hover/focus for now as the behavior on desktop would not match mobile. We intend to update the menu more extensively to be fully accessible in the future. 

**FYI:** The mobile menu needs some accessibility work as well to be keyboard accessible but I think we can separate that work out for a separate issue for now. 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

Resolves #224 