### PR TITLE
Adding lazy load option to card section module

### DIFF
--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -17,7 +17,7 @@
         "show_loading" : true,
         "default": {
           "alt": "A blue puzzle piece",
-          "loading" : "disabled",
+          "loading" : "lazy",
           "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         }
       },
@@ -39,7 +39,7 @@
       {
         "image": {
           "alt": "A blue puzzle piece",
-          "loading" : "disabled",
+          "loading" : "lazy",
           "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         },
         "title": "This is a title",
@@ -48,7 +48,7 @@
       {
         "image": {
           "alt": "A blue puzzle piece",
-          "loading" : "disabled",
+          "loading" : "lazy",
           "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         },
         "title": "This is a title",
@@ -57,7 +57,7 @@
       {
         "image": {
           "alt": "A blue puzzle piece",
-          "loading" : "disabled",
+          "loading" : "lazy",
           "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         },
         "title": "This is a title",

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -14,11 +14,11 @@
         "name": "image",
         "type": "image",
         "resizable": false,
+        "show_loading" : true,
         "default": {
           "alt": "A blue puzzle piece",
-          "height": 32,
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "width": 35
+          "loading" : "disabled",
+          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         }
       },
       {
@@ -39,9 +39,8 @@
       {
         "image": {
           "alt": "A blue puzzle piece",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "height": 32,
-          "width": 35
+          "loading" : "disabled",
+          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         },
         "title": "This is a title",
         "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
@@ -49,9 +48,8 @@
       {
         "image": {
           "alt": "A blue puzzle piece",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "height": 32,
-          "width": 35
+          "loading" : "disabled",
+          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         },
         "title": "This is a title",
         "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
@@ -59,9 +57,8 @@
       {
         "image": {
           "alt": "A blue puzzle piece",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "height": 32,
-          "width": 35
+          "loading" : "disabled",
+          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png"
         },
         "title": "This is a title",
         "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -1,8 +1,10 @@
+{% set loadingAttr = module.image_field.loading != 'disabled' ? 'loading="{{ module.image_field.loading }}"' : '' %}
+
 <div class="cards">
   {% for card in module.card %}
     <div class="cards__card card">
       {% if card.image.src %}
-        <img class="card__image" src="{{ card.image.src }}" alt="{{ card.image.alt }}" width="{{ card.image.width }}" height="{{ card.image.height }}">
+        <img class="card__image" src="{{ card.image.src }}" alt="{{ card.image.alt }}" width="{{ card.image.width }}" height="{{ card.image.height }}" {{ loadingAttr }}>
       {% endif %}
       <div class="card__text">
         {% if card.title %}

--- a/src/templates/contact.html
+++ b/src/templates/contact.html
@@ -30,24 +30,27 @@
             card=[
               {
                 'image': {
-                  'src': get_asset_url('../images/phone.png'),
-                  'alt': 'Phone number'
+                  'alt': 'Phone number',
+                  'loading': 'disabled',
+                  'src': get_asset_url('../images/phone.png')
                 },
                 'text': '(887) 929-0687',
                 'title': ''
               },
               {
                 'image': {
-                  'src': get_asset_url('../images/email.png'),
-                  'alt': 'Email'
+                  'alt': 'Email',
+                  'loading': 'disabled',
+                  'src': get_asset_url('../images/email.png')
                 },
                 'text': 'contact@business.com',
                 'title': ''
               },
               {
                 'image': {
-                  'src': get_asset_url('../images/location.png'),
-                  'alt': 'Address'
+                  'alt': 'Address',
+                  'loading': 'disabled',
+                  'src': get_asset_url('../images/location.png')
                 },
                 'text': '2 Canal Park, Cambridge, MA 02141',
                 'title': ''


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [X] New feature (change which adds new functionality)

**Description**

Adding in the new [lazy loading](https://developers.hubspot.com/docs/cms/guides/speed/lazy-loading) option to images fields in custom modules (the only custom module that used this was card section). I defaulted the module to be set to `lazy` but the instance on the contact page to be set to `disabled` as all of the images show above the fold on desktop. 

![lazy-load](https://user-images.githubusercontent.com/22665237/99683074-f10de480-2a4d-11eb-9121-8262eb9a83a9.png)

**Relevant links**

Fixes #264 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
@TheWebTech @ajlaporte 
