### PR TITLE
Setting fallback property for fonts in fields.json

### DIFF
--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -369,7 +369,7 @@ body .navigation-primary a,
 .header__language-switcher-label-current,
 .header__language-switcher .lang_list_class li a {
   color: {{ header_nav_link_color }};
-  font-family: {{ body_font.font }};
+  font-family: {{ body_font.font }}, {{ body_font.fallback }};
 }
 
 body .navigation-primary a:hover,
@@ -419,7 +419,7 @@ body .submenu.level-2 > li:first-child.focus:before {
 
 .header__language-switcher-label-current,
 .header__language-switcher .lang_list_class li a {
-  font-family: {{ body_font.font }};
+  font-family: {{ body_font.font }}, {{ body_font.fallback }};
 }
 
 .header__language-switcher-label-current:after {

--- a/src/fields.json
+++ b/src/fields.json
@@ -54,6 +54,7 @@
           }
         },
         "default": {
+          "fallback": "sans-serif",
           "font": "Lato",
           "font_set": "GOOGLE"
         }
@@ -75,6 +76,7 @@
           }
         },
         "default": {
+          "fallback": "serif",
           "font": "Merriweather",
           "font_set": "GOOGLE"
         }
@@ -143,6 +145,7 @@
         "inherited_value": {
           "property_value_paths": {
             "color": "theme.global_fonts.primary_font.color",
+            "fallback": "theme.global_fonts.primary_font.fallback",
             "font": "theme.global_fonts.primary_font.font",
             "font_set": "theme.global_fonts.primary_font.font_set"
           }
@@ -160,6 +163,7 @@
         "inherited_value": {
           "property_value_paths": {
             "color": "theme.global_fonts.secondary_font.color",
+            "fallback": "theme.global_fonts.secondary_font.fallback",
             "font": "theme.global_fonts.secondary_font.font",
             "font_set": "theme.global_fonts.secondary_font.font_set"
           }
@@ -181,6 +185,7 @@
         "inherited_value": {
           "property_value_paths": {
             "color": "theme.global_fonts.secondary_font.color",
+            "fallback": "theme.global_fonts.secondary_font.fallback",
             "font": "theme.global_fonts.secondary_font.font",
             "font_set": "theme.global_fonts.secondary_font.font_set"
           }
@@ -202,6 +207,7 @@
         "inherited_value": {
           "property_value_paths": {
             "color": "theme.global_fonts.secondary_font.color",
+            "fallback": "theme.global_fonts.secondary_font.fallback",
             "font": "theme.global_fonts.secondary_font.font",
             "font_set": "theme.global_fonts.secondary_font.font_set"
           }
@@ -223,6 +229,7 @@
         "inherited_value": {
           "property_value_paths": {
             "color": "theme.global_fonts.secondary_font.color",
+            "fallback": "theme.global_fonts.secondary_font.fallback",
             "font": "theme.global_fonts.secondary_font.font",
             "font_set": "theme.global_fonts.secondary_font.font_set"
           }
@@ -242,6 +249,7 @@
         "load_external_fonts": true,
         "inherited_value": {
           "property_value_paths": {
+            "fallback": "theme.global_fonts.secondary_font.fallback",
             "font": "theme.global_fonts.secondary_font.font",
             "font_set": "theme.global_fonts.secondary_font.font_set"
           }
@@ -263,6 +271,7 @@
         "inherited_value": {
           "property_value_paths": {
             "color": "theme.global_fonts.secondary_font.color",
+            "fallback": "theme.global_fonts.secondary_font.fallback",
             "font": "theme.global_fonts.secondary_font.font",
             "font_set": "theme.global_fonts.secondary_font.font_set"
           }


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Setting the `fallback` property on fonts in `fields.json` so that a more appropriate fallback was set (e.g. sans-serif for a sans-serif Google font). 

![Fallback-font](https://user-images.githubusercontent.com/22665237/101819987-f5c93400-3af3-11eb-84e1-22d0cb58f195.png)

**Relevant links**

Fixes #281 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
@jmclaren @ajlaporte
