### PR TITLE
Split out fallback

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -141,7 +141,7 @@ The style guide for the HubSpot CMS boilerplate. Please use this style guide as 
 10. Wrap long lines to increase readability (wrap at 100 characters).
 11. Don't close void elements.
   - `<br>` over `<br />`
-12. Omit type attributes for stylesheets and scripts.
+12. Omit type attributes for style sheets and scripts.
 ```html
 <!-- Good example -->
 <link rel="stylesheet" href="mystyle.css">

--- a/src/css/components/_footer.css
+++ b/src/css/components/_footer.css
@@ -1,5 +1,4 @@
 .footer {
-  background-color: #F8FAFC;
   text-align: center;
 }
 

--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -1,9 +1,5 @@
 /* Header container */
 
-.header {
-  background-color: #F8FAFC;
-}
-
 .header__container {
   display: flex;
   justify-content: space-between;
@@ -135,7 +131,7 @@
 }
 
 .header__language-switcher .lang_list_class {
-  border: 2px solid #D1D6DC;
+  border: 2px solid;
   border-radius: 6px;
   box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.2);
   color: #494A52;
@@ -159,7 +155,6 @@
 }
 
 .header__language-switcher .lang_list_class:before {
-  border-bottom-color: #D1D6DC;
   left: 70%;
   top: -25px;
 }
@@ -170,7 +165,6 @@
 }
 
 .header__language-switcher .lang_list_class.first-active::after {
-  border-bottom-color: #EBEFF3;
   top: -22px;
   transition: 0.3s;
 }
@@ -194,15 +188,6 @@
 .header__language-switcher .lang_list_class li:hover {
   background-color: #EBEFF3;
   transition: background-color 0.3s;
-}
-
-.header__language-switcher .lang_list_class li a {
-  color: #494A52;
-  font-family: Lato, serif;
-}
-
-.header__language-switcher .lang_list_class li a:hover {
-  color: #494A52;
 }
 
 .header__language-switcher--label {

--- a/src/css/elements/_buttons.css
+++ b/src/css/elements/_buttons.css
@@ -1,9 +1,5 @@
 button,
 .button {
-  background-color: #494A52;
-  border: 1px solid #494A52;
-  border-radius: 6px;
-  color: #FFF;
   cursor: pointer;
   display: inline-block;
   font-size: 0.92rem;
@@ -11,14 +7,12 @@ button,
   height: auto;
   line-height: 1.1;
   margin: 0;
-  padding: 15px 53px;
   position: relative;
   text-align: center;
   text-decoration: none;
   transition: all 0.15s linear;
   white-space: normal;
   width: auto;
-  word-break: break-word;
 }
 
 button:disabled,
@@ -32,16 +26,10 @@ button:hover,
 button:focus,
 .button:hover,
 .button:focus {
-  background-color: #21222A;
-  border-color: #21222A;
-  color: #FFF;
   text-decoration: none;
 }
 
 button:active,
 .button:active {
-  background-color: #71727A;
-  border-color: #71727A;
-  color: #FFF;
   text-decoration: none;
 }

--- a/src/css/elements/_forms.css
+++ b/src/css/elements/_forms.css
@@ -1,9 +1,5 @@
 /* Form */
 
-form {
-  font-family: Lato, sans-serif;
-}
-
 .hs-form-field {
   margin-bottom: 1.4rem;
 }
@@ -11,7 +7,6 @@ form {
 /* Labels */
 
 form label {
-  color: #33475B;
   display: block;
   font-size: 0.875rem;
   padding-top: 0;
@@ -23,7 +18,6 @@ form label {
 /* Help text - legends */
 
 form legend {
-  color: #33475B;
   font-size: 0.875rem;
 }
 
@@ -42,40 +36,16 @@ input[type=file],
 select,
 textarea {
   background-color: #FFF;
-  border: 2px solid #D1D6DC;
+  border: 2px solid;
   border-radius: 3px;
-  color: #33475B;
   display: inline-block;
   font-size: 0.875rem;
   padding: 0.7rem;
   width: 100%;
 }
 
-input[type=text]:focus,
-input[type=email]:focus,
-input[type=password]:focus,
-input[type=tel]:focus,
-input[type=number]:focus,
-input[type=file]:focus,
-select:focus,
-textarea:focus {
-  outline-color: rgba(82, 168, 236, 0.8);
-}
-
 fieldset {
   max-width: 100% !important;
-}
-
-::-moz-placeholder {
-  color: #BFBFBF;
-}
-
-:-ms-input-placeholder {
-  color: #BFBFBF;
-}
-
-::placeholder {
-  color: #BFBFBF;
 }
 
 /* Inputs - checkbox/radio */
@@ -125,18 +95,12 @@ form .inputs-list {
   color: #FFF;
 }
 
-.fn-date-picker td.is-today .pika-button {
-  color: #343A40;
-}
-
 .fn-date-picker td.is-selected .pika-button {
-  background: #343A40;
   border-radius: 0;
   box-shadow: none;
 }
 
 .fn-date-picker td .pika-button:hover {
-  background-color: #343A40 !important;
   border-radius: 0 !important;
   color: #FFF;
 }
@@ -195,10 +159,6 @@ form .header {
 
 form input[type=submit],
 form .hs-button {
-  background-color: #494A52;
-  border: 1px solid #494A52;
-  border-radius: 6px;
-  color: #FFF;
   cursor: pointer;
   display: inline-block;
   font-size: 0.92rem;
@@ -206,7 +166,6 @@ form .hs-button {
   height: auto;
   line-height: 1.1;
   margin: 0;
-  padding: 15px 53px;
   position: relative;
   text-align: center;
 /* default "Get Free Widget" form (renders when no form is passed to the form HubL tag) is an anchor (a.hs-button) rather than a real input, so it needs explcit css to avoid link styling */
@@ -215,24 +174,6 @@ form .hs-button {
   white-space: normal;
   width: auto;
   word-break: break-word;
-}
-
-form input[type=submit]:hover,
-form input[type=submit]:focus,
-form .hs-button:hover,
-form .hs-button:focus {
-  background-color: #21222A;
-  border-color: #21222A;
-/* see "no form selected" note above */
-  color: #FFF;
-}
-
-form input[type=submit]:active,
-form .hs-button:active {
-  background-color: #71727A;
-  border-color: #71727A;
-/* see "no form selected" note above */
-  color: #FFF;
 }
 
 /* Captcha */

--- a/src/css/elements/_tables.css
+++ b/src/css/elements/_tables.css
@@ -1,20 +1,20 @@
 /* Table */
 
 table {
-  border: 1px solid #DEE2E6;
+  border: 1px solid;
   margin-bottom: 1.4rem;
   overflow-wrap: break-word;
 }
 
 tbody + tbody {
-  border-top: 2px solid #DEE2E6;
+  border-top: 2px solid;
 }
 
 /* Table Cells */
 
 th,
 td {
-  border: 1px solid #DEE2E6;
+  border: 1px solid;
   padding: 0.75rem;
   vertical-align: top;
 }
@@ -23,8 +23,6 @@ td {
 
 thead th,
 thead td {
-  background-color: #343A40;
-  border-bottom: 2px solid #DEE2E6;
-  color: #FFF;
+  border-bottom: 2px solid;
   vertical-align: bottom;
 }

--- a/src/css/elements/_typography.css
+++ b/src/css/elements/_typography.css
@@ -1,22 +1,4 @@
-html {
-  font-size: 24px;
-}
-
-@media (max-width: 767px) {
-  html {
-    font-size: 18px;
-  }
-}
-
-@media (max-width: 480px) {
-  html {
-    font-size: 16px;
-  }
-}
-
 body {
-  color: #494A52;
-  font-family: Lato, sans-serif;
   line-height: 1.4;
   word-break: break-word;
 }
@@ -42,7 +24,6 @@ strong {
 /* Anchors */
 
 a {
-  color: #0270E0;
   cursor: pointer;
   text-decoration: none;
 }
@@ -59,43 +40,14 @@ h3,
 h4,
 h5,
 h6 {
-  color: #494A52;
-  font-family: Merriweather, serif;
-  font-weight: 700;
   margin: 0 0 1.4rem;
-}
-
-h1 {
-  font-size: 2.1rem;
-}
-
-h2 {
-  font-size: 1.6rem;
-}
-
-h3 {
-  font-size: 1.25rem;
-}
-
-h4 {
-  font-family: Lato, sans-serif;
-  font-size: 1.175rem;
-  font-weight: normal;
-}
-
-h5 {
-  font-size: 1rem;
-}
-
-h6 {
-  font-size: 0.9rem;
 }
 
 /* Lists */
 
 ul,
 ol {
-  margin: 0 0 1.5rem;
+  margin: 0 0 1.4rem;
 }
 
 ul ul,
@@ -118,7 +70,7 @@ code {
 /* Blockquotes */
 
 blockquote {
-  border-left: 2px solid #A9A9A9;
+  border-left: 2px solid;
   margin: 0 0 1.4rem;
   padding-left: 15px;
 }

--- a/src/css/fallback.css
+++ b/src/css/fallback.css
@@ -1,0 +1,446 @@
+/*
+Purpose: a style sheet that matches the CSS output from theme-overrides.css for use if a developer doesn't want to provide theme settings.
+
+Instructions for developers who use theme settings in their theme:
+1. Delete fallback.css
+
+Instructions for developers who don't use theme settings in their theme:
+1. Remove the theme settings from fields.json
+2. Delete theme-overrides.css and remove the reference to theme-overrides.css from base.html
+3a. Add a reference to fallback.css in base.html
+-or-
+3b. Copy the CSS from the different sections fallback.css and paste the code into the relevant style sheet in the CSS folder (e.g. the CSS from the typography section can be copy and pasted into the typography.css file).
+*/
+
+/*****************************************/
+/***** Containers / Grid / DnD Areas *****/
+/*****************************************/
+
+.content-wrapper {
+  max-width: 1240px;
+}
+
+.dnd-section,
+.content-wrapper--vertical-spacing {
+  padding: 80px 20px;
+}
+
+.dnd-section > .row-fluid {
+  max-width: 1240px;
+}
+
+/*****************************************/
+/************** Typography ***************/
+/*****************************************/
+
+html {
+  font-size: 24px;
+}
+
+body {
+  color: #494A52;
+  font-family: Lato, sans-serif;
+}
+
+p {
+  font-family: Lato, sans-serif;
+}
+
+a {
+  color: #0270E0;
+}
+
+a:hover,
+a:focus {
+  color: #0048B8;
+}
+
+a:active {
+  color: #2A98FF;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #494A52;
+  font-family: Merriweather, serif;
+  font-weight: 700;
+}
+
+h1 {
+  font-size: 50px;
+}
+
+h2 {
+  font-size: 38px;
+}
+
+h3 {
+  font-size: 30px;
+}
+
+h4 {
+  font-size: 24px;
+  font-weight: normal;
+}
+
+h5 {
+  color: #000;
+  font-size: 16px;
+  font-weight: normal;
+}
+
+h6 {
+  font-size: 14px;
+  font-weight: normal;
+}
+
+blockquote {
+  border-left-color: #F8FAFC;
+}
+
+/*****************************************/
+/*************** Buttons *****************/
+/*****************************************/
+
+button,
+.button {
+  background-color: #494A52;
+  border: 1px solid #494A52;
+  border-radius: 6px;
+  color: #FFF;
+  padding: 15px 53px;
+}
+
+button:hover,
+button:focus,
+.button:hover,
+.button:focus {
+  background-color: #21222A;
+  border-color: #21222A;
+  color: #FFF;
+}
+
+button:active,
+.button:active {
+  background-color: #71727A;
+  border-color: #71727A;
+  color: #FFF;
+}
+
+/*****************************************/
+/**************** Forms ******************/
+/*****************************************/
+
+form,
+.submitted-message {
+  font-family: Lato, sans-serif;
+}
+
+h3.form-title {
+  background-color: #494A52;
+  color: #F8FAFC;
+}
+
+form label {
+  color: #494A52;
+}
+
+form legend {
+  color: #494A52;
+}
+
+input[type=text],
+input[type=email],
+input[type=password],
+input[type=tel],
+input[type=number],
+input[type=file],
+select,
+textarea {
+  border-color: #D1D6DC;
+  color: #494A52;
+}
+
+input[type=text]:focus,
+input[type=email]:focus,
+input[type=password]:focus,
+input[type=tel]:focus,
+input[type=number]:focus,
+input[type=file]:focus,
+select:focus,
+textarea:focus {
+  border-color: #494A52;
+}
+
+::-webkit-input-placeholder {
+  color: #494A52;
+}
+
+::-webkit-input-placeholder,
+::-moz-placeholder,
+:-ms-input-placeholder,
+:-moz-placeholder,
+::placeholder,
+.hs-fieldtype-date .input .hs-dateinput:before {
+  color: #494A52;
+}
+
+.fn-date-picker td.is-selected .pika-button {
+  background: #494A52;
+}
+
+.fn-date-picker td .pika-button:hover {
+  background-color: #494A52 !important;
+}
+
+.fn-date-picker td.is-today .pika-button {
+  color: #494A52;
+}
+
+form input[type=submit],
+form .hs-button {
+  background-color: #494A52;
+  border: 1px solid #494A52;
+  border-radius: 6px;
+  color: #FFF;
+  padding: 15px 53px;
+}
+
+form input[type=submit]:hover,
+form input[type=submit]:focus,
+form .hs-button:hover,
+form .hs-button:focus {
+  background-color: #21222A;
+  border-color: #21222A;
+  color: #FFF;
+}
+
+form input[type=submit]:active,
+form .hs-button:active {
+  background-color: #71727A;
+  border-color: #71727A;
+  color: #FFF;
+}
+
+/*****************************************/
+/**************** Tables *****************/
+/*****************************************/
+
+table {
+  background-color: #FFF;
+  border-color: #494A52;
+}
+
+th,
+td {
+  border-color: #494A52;
+  color: #494A52;
+}
+
+thead th,
+thead td {
+  background-color: #494A52;
+  border-bottom-color: #494A52;
+  color: #FFF;
+}
+
+tfoot td {
+  background-color: #FFF;
+  color: #494A52;
+}
+
+tbody + tbody {
+  border-top-color: #494A52;
+}
+
+/*****************************************/
+/**************** Header *****************/
+/*****************************************/
+
+.header {
+  background-color: #F8FAFC;
+}
+
+body .navigation-primary a,
+.header__logo .logo-company-name,
+.header__language-switcher-label-current,
+.header__language-switcher .lang_list_class li a {
+  color: #494A52;
+  font-family: Lato, sans-serif;
+}
+
+body .navigation-primary a:hover,
+body .navigation-primary a:focus,
+.header__language-switcher-label-current:hover,
+.header__language-switcher-label-current:focus,
+.header__language-switcher .lang_list_class li:hover a,
+.header__language-switcher .lang_list_class li a:focus {
+  color: #21222A;
+}
+
+body .navigation-primary a:active,
+body .header__language-switcher-label-current:active,
+body .header__language-switcher .lang_list_class li a:active {
+  color: #71727A;
+}
+
+body .navigation-primary .submenu.level-1 > li > a.active-item:after {
+  background-color: #494A52;
+}
+
+body .submenu.level-2,
+body .header__language-switcher .lang_list_class {
+  background-color: #F8FAFC;
+  border-color: #494A52;
+}
+
+body .submenu.level-2 > li:first-child:before {
+  border-color: #494A52;
+}
+
+body .header__language-switcher .lang_list_class:before {
+  border-bottom-color: #494A52;
+}
+
+body .submenu.level-2 .menu-item .menu-link:hover,
+body .submenu.level-2 .menu-item .menu-link:focus,
+body .header__language-switcher .lang_list_class li:hover,
+body .submenu.level-2 > li:first-child:hover:before,
+body .submenu.level-2 > li:first-child.focus:before {
+  background-color: #F8FAFC;
+}
+
+.header__language-switcher .lang_list_class.first-active::after {
+  border-bottom-color: #F8FAFC;
+}
+
+.header__language-switcher-label-current,
+.header__language-switcher .lang_list_class li a {
+  font-family: Lato, sans-serif;
+}
+
+.header__language-switcher-label-current:after {
+  border-top-color: #494A52;
+}
+
+@media(max-width: 767px) {
+  .header__navigation {
+    background-color:#F8FAFC;
+  }
+
+  .header__navigation-toggle svg,.menu-arrow svg {
+    fill: #494A52;
+  }
+}
+
+/*****************************************/
+/**************** Footer *****************/
+/*****************************************/
+
+.footer {
+  background-color: #F8FAFC;
+}
+
+.footer h1,
+.footer h2,
+.footer h3,
+.footer h4,
+.footer h5,
+.footer h6,
+.footer p,
+.footer a,
+.footer div,
+.footer span {
+  color: #494A52;
+}
+
+/*****************************************/
+/***************** Blog ******************/
+/*****************************************/
+
+.blog-post__date {
+  border-color: #494A52;
+}
+
+.blog-tag-filter__menu-link,
+.blog-post__tag-link,.blog-card__tag-link,
+.blog-post__author-name,.blog-card__title a {
+  color: #494A52;
+}
+
+.blog-card__tag-link:hover,
+.blog-card__title a:hover,
+.blog-tag-filter__menu-link:hover,
+.blog-post__tag-link:hover,
+.blog-post__author-name:hover,
+.blog-card__tag-link:focus,
+.blog-card__title a:focus,
+.blog-tag-filter__menu-link:focus,
+.blog-post__tag-link:focus,
+.blog-post__author-name:focus {
+  color: #21222A;
+}
+
+.blog-card__tag-link:active,
+.blog-card__title a:active,
+.blog-tag-filter__menu-link:active,
+.blog-post__tag-link:active,
+.blog-post__author-name:active {
+  color: #71727A;
+}
+
+.blog-tag-filter__menu-link--active-item:after {
+  background-color: #494A52;
+}
+
+.blog-pagination__link {
+  color: #494A52;
+}
+
+.blog-pagination__link--active:after,
+.blog-pagination__prev-link:after,
+.blog-pagination__next-link:after {
+  background-color: #494A52;
+}
+
+.blog-post__author {
+  background-color: #F8FAFC;
+}
+
+#comments-listing .comment-reply-to {
+  color: #0270E0;
+}
+
+#comments-listing .comment-reply-to:hover,
+#comments-listing .comment-reply-to:focus {
+  color: #0048B8;
+}
+
+#comments-listing .comment-reply-to:active {
+  color: #2A98FF;
+}
+
+/*****************************************/
+/*************** Modules *****************/
+/*****************************************/
+
+body .icon svg {
+  fill: #494A52;
+}
+
+body .tns-nav button.tns-nav-active {
+  background-color: #494A52;
+}
+
+body .tns-nav button:hover,
+body .tns-nav button:focus {
+  background-color: #494A52;
+}
+
+body .team-member__description {
+  background-color: #F8FAFC;
+}

--- a/src/css/objects/_containers-dnd.css
+++ b/src/css/objects/_containers-dnd.css
@@ -1,6 +1,5 @@
 .content-wrapper {
   margin: 0 auto;
-  max-width: 1240px;
   padding: 0 20px;
 }
 
@@ -10,14 +9,8 @@
   }
 }
 
-.dnd-section,
-.content-wrapper--vertical-spacing {
-  padding: 80px 20px;
-}
-
 .dnd-section > .row-fluid {
   margin: 0 auto;
-  max-width: 1200px;
 }
 
 .dnd-section .dnd-column {

--- a/src/css/templates/_blog.css
+++ b/src/css/templates/_blog.css
@@ -169,7 +169,6 @@
 .blog-pagination__link {
   border: 2px solid transparent;
   border-radius: 7px;
-  color: #494A52;
   display: inline-flex;
   line-height: 1;
   margin: 0 0.1rem;
@@ -343,6 +342,5 @@
 
 .blog-comments .comment-reply-to:hover {
   background-color: transparent;
-  color: #494A52;
   text-decoration: underline;
 }


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This change splits out fallback CSS for `theme-overrides.css` from the `main.css` file into a separate `fallback.css` file which is optionally available if a developer doesn't want to use theme settings. The original purpose of putting fallback CSS for `theme-overrides.css` within `main.css` was so that a developer could use boilerplate with theme settings or without theme settings. The reason for this PR is to remove this redundant CSS from `main.css` which slightly helps performance (removes some unused render blocking CSS) and makes the CSS in `main.css` a bit easier to understand while still maintaining an option for developers who don't want to use theme settings. 

**Relevant links**

Resolves #285 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
