### PR TITLE
Remove unused or redundant CSS

### DIFF
--- a/src/css/components/_footer.css
+++ b/src/css/components/_footer.css
@@ -2,7 +2,7 @@
   text-align: center;
 }
 
-.footer__container.content-wrapper {
+.footer__container {
   padding: 1rem 0;
 }
 

--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -216,8 +216,7 @@
   border-radius: 0 0 6px 6px;
 }
 
-.header__language-switcher .lang_list_class li:hover,
-.header__language-switcher .lang_list_class li:focus {
+.header__language-switcher .lang_list_class li:hover {
   background-color: #EBEFF3;
   transition: background-color 0.3s;
 }
@@ -278,8 +277,7 @@
     background-image: none;
   }
 
-  .header__language-switcher .lang_list_class li:hover,
-  .header__language-switcher .lang_list_class li:focus {
+  .header__language-switcher .lang_list_class li:hover{
     background-color: inherit;
   }
 

--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -5,6 +5,10 @@
   justify-content: space-between;
 }
 
+.header__row-1 {
+  padding-top: 20px;
+}
+
 .header__row-1,
 .header__row-2 {
   align-items: center;
@@ -13,8 +17,30 @@
   width: 100%;
 }
 
-.header__row-1 {
-  padding-top: 20px;
+@media (max-width: 1150px) and (min-width: 767px) {
+  .header__column {
+    width: 100%;
+  }
+}
+
+@media (max-width: 767px) {
+  .header__container {
+    flex-direction: column;
+    padding: 20px 0 0;
+  }
+
+  .header__column {
+    position: relative;
+  }
+
+  .header__row-1 {
+    padding-top: 0;
+  }
+
+  .header__row-2 {
+    justify-content: center;
+    padding: 30px;
+  }
 }
 
 /* Navigation skipper */
@@ -29,9 +55,9 @@
   width: 1px;
 }
 
-.header__skip:active,
+.header__skip:hover,
 .header__skip:focus,
-.header__skip:hover {
+.header__skip:active {
   height: auto;
   left: 0;
   overflow: visible;
@@ -48,6 +74,13 @@
   margin-right: auto;
   max-width: 200px;
   overflow: hidden;
+}
+
+@media (max-width: 767px) {
+  .header__logo {
+    margin: 0 auto;
+    width: 100%;
+  }
 }
 
 .header__logo img {
@@ -71,32 +104,24 @@
 }
 
 .header__search .hs-search-field__input {
-  background-color: #FFF;
   background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5TZWFyY2g8L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+ICAgICAgICA8cGF0aCBkPSJNOS4xMzg2MTUzNCwxNS44OTI1Njg1IEM1LjQxMzk1NzQyLDE1Ljg5MjU2ODUgMi4zODM4ODUyNywxMi44NjM0NDc1IDIuMzgzODg1MjcsOS4xMzkwMDM3NiBDMi4zODM4ODUyNyw1LjQxNDU2MDA1IDUuNDEzOTU3NDIsMi4zODM4ODUyNyA5LjEzODYxNTM0LDIuMzgzODg1MjcgQzEyLjg2MzI3MzMsMi4zODM4ODUyNyAxNS44OTI1Njg1LDUuNDE0NTYwMDUgMTUuODkyNTY4NSw5LjEzOTAwMzc2IEMxNS44OTI1Njg1LDEyLjg2MzQ0NzUgMTIuODYzMjczMywxNS44OTI1Njg1IDkuMTM4NjE1MzQsMTUuODkyNTY4NSBNOS4xMzg3NTI0NSwyLjQzMzYwODg3ZS0xMyBDMTQuMTc3OTk1NSwyLjQzMzYwODg3ZS0xMyAxOC4yNzY0NTM3LDQuMTAwMzI0NzEgMTguMjc2NDUzNyw5LjEzOTI3Nzk2IEMxOC4yNzY0NTM3LDExLjIyOTgyMTEgMTcuNTcxMDE2OSwxMy4xNTg0NDM0IDE2LjM4NTYzMTMsMTQuNjk5NjY5NiBMMjMuNjUwODg4MSwyMS45NjUyMjY2IEMyNC4xMTYzNzA2LDIyLjQzMDcwOTIgMjQuMTE2MzcwNiwyMy4xODU0MDU1IDIzLjY1MDg4ODEsMjMuNjUwODg4MSBDMjMuMTg1NDA1NSwyNC4xMTYzNzA2IDIyLjQzMDcwOTIsMjQuMTE2MzcwNiAyMS45NjUyMjY2LDIzLjY1MDg4ODEgTDE0LjY5OTgxMzMsMTYuMzg1NDcxMyBDMTMuMTU4NDQwNSwxNy41NzA5NTA5IDExLjIyOTU3MzgsMTguMjc2NDUzNyA5LjEzODc1MjQ1LDE4LjI3NjQ1MzcgQzQuMDk5NTA5MzgsMTguMjc2NDUzNyAtMy43MzAzNDkzNmUtMTQsMTQuMTc4MjMxMiAtMy43MzAzNDkzNmUtMTQsOS4xMzkyNzc5NiBDLTMuNzMwMzQ5MzZlLTE0LDQuMTAwMzI0NzEgNC4wOTk1MDkzOCwyLjQzMzYwODg3ZS0xMyA5LjEzODc1MjQ1LDIuNDMzNjA4ODdlLTEzIFoiIGlkPSJwYXRoLTEiPjwvcGF0aD4gICAgPC9kZWZzPiAgICA8ZyBpZD0iU2VhcmNoIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4gICAgICAgIDxtYXNrIGlkPSJtYXNrLTIiIGZpbGw9IndoaXRlIj4gICAgICAgICAgICA8dXNlIHhsaW5rOmhyZWY9IiNwYXRoLTEiPjwvdXNlPiAgICAgICAgPC9tYXNrPiAgICAgICAgPHVzZSBpZD0iSWNvbnMvQWN0aW9ucy9TZWFyY2giIGZpbGw9IiM0OTRBNTIiIHhsaW5rOmhyZWY9IiNwYXRoLTEiPjwvdXNlPiAgICA8L2c+PC9zdmc+);
   background-position: center right 15px;
   background-repeat: no-repeat;
-  border: 1.79px solid #D1D6DC;
-  border-radius: 6px;
-  color: #494A52;
-  font-family: Lato, serif;
-  font-size: 22px;
-  font-weight: 300;
   height: 45px;
   padding: 0 15px;
 }
 
 .header__search .hs-search-field--open .hs-search-field__input {
-  border: 1.79px solid #D1D6DC;
   border-bottom: none;
   border-radius: 6px 6px 0 0;
-  background-color: #FFF;
+  max-width: 100%;
 }
 
 .header__search .hs-search-field--open .hs-search-field__suggestions {
   background-color: #FFF;
-  border: 1.79px solid #D1D6DC;
-  border-top: -2px solid #FFF;
+  border: 2px solid #D1D6DC;
   border-radius: 0 0 6px 6px;
+  border-top-width: 1px;
   position: absolute;
   width: 100%;
   z-index: 10;
@@ -104,13 +129,12 @@
 
 .header__search .hs-search-field__suggestions li {
   border-top: 1px solid #D1D6DC;
-  font-family: Lato, serif;
-  font-size: 22px;
+  font-size: 0.875rem;
 }
 
 .header__search .hs-search-field__suggestions li a {
   color: #494A52;
-  padding: 3px 15px;
+  padding: 10px 15px;
   text-decoration: none;
   transition: background-color 0.3s;
 }
@@ -118,6 +142,15 @@
 .header__search .hs-search-field__suggestions #results-for {
   display: none;
 }
+
+@media (max-width: 767px) {
+  .header__search {
+    border-top: 2px solid #CED4DB;
+    order: 1;
+    padding: 30px;
+  }
+}
+
 
 /* Language switcher */
 
@@ -134,10 +167,7 @@
   border: 2px solid;
   border-radius: 6px;
   box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.2);
-  color: #494A52;
   display: block;
-  font-family: Lato, serif;
-  font-size: 0.8rem;
   left: calc(100% - 24px);
   opacity: 0;
   min-width: 100px;
@@ -148,7 +178,8 @@
   visibility: hidden;
 }
 
-.header__language-switcher:hover .lang_list_class {
+.header__language-switcher:hover .lang_list_class,
+.header__language-switcher:focus .lang_list_class {
   opacity: 1;
   transition: opacity 0.3s;
   visibility: visible;
@@ -185,7 +216,8 @@
   border-radius: 0 0 6px 6px;
 }
 
-.header__language-switcher .lang_list_class li:hover {
+.header__language-switcher .lang_list_class li:hover,
+.header__language-switcher .lang_list_class li:focus {
   background-color: #EBEFF3;
   transition: background-color 0.3s;
 }
@@ -215,41 +247,57 @@
   width: 0px;
 }
 
+@media (max-width: 767px) {
+  .header__language-switcher {
+    border-top: 2px solid #CED4DB;
+    padding-left: 30px;
+    padding-right: 0;
+  }
+
+  .header__language-switcher .lang_list_class {
+    border: none;
+    box-shadow: unset;
+    display: block;
+    left: 30px;
+    opacity: 1;
+    padding: 0 30px;
+    top: 0;
+    visibility: visible;
+  }
+
+  .header__language-switcher .lang_list_class li {
+    background-color: inherit;
+    font-size: 22px;
+  }
+
+  .header__language-switcher--label-current {
+    display: none;
+  }
+
+  .header__language-switcher .globe_class {
+    background-image: none;
+  }
+
+  .header__language-switcher .lang_list_class li:hover,
+  .header__language-switcher .lang_list_class li:focus {
+    background-color: inherit;
+  }
+
+  .header__language-switcher .lang_list_class:before,
+  .header__language-switcher .lang_list_class:after {
+    content: none;
+  }
+}
+
 /* Navigation */
 
 #nav-toggle {
   display: none;
 }
 
-.header__menu--flex {
-  display: flex;
-}
-
-/* Tablet styles */
-
-@media (max-width: 1150px) and (min-width: 767px) {
-  .header__column {
-    width: 100%;
-  }
-}
-
-/* Mobile styles */
+/* Mobile toggles */
 
 @media (max-width: 767px) {
-  .header__container {
-  flex-direction: column;
-    padding: 20px 0 0;
-  }
-
-  .header__container form {
-    max-width: 100%;
-  }
-
-  .header__logo {
-    margin: 0 auto;
-    width: 100%;
-  }
-
   .header__navigation,
   .header__search,
   .header__language-switcher {
@@ -293,13 +341,6 @@
     margin-right: auto;
   }
 
-  .header__navigation--toggle.open:after,
-  .header__search--toggle.open:after,
-  .header__language-switcher--toggle.open:after {
-    display: block;
-    word-break: normal;
-  }
-
   .header__navigation--toggle:after,
   .header__search--toggle:after,
   .header__language-switcher--toggle:after {
@@ -312,25 +353,16 @@
     top: -10px;
   }
 
-  .header__column {
-    position: relative;
-  }
-
-  .header__row-1 {
-    padding-top: 0;
-  }
-
-  .header__row-2 {
-    justify-content: center;
-    padding: 30px;
+  .header__navigation--toggle.open:after,
+  .header__search--toggle.open:after,
+  .header__language-switcher--toggle.open:after {
+    display: block;
+    word-break: normal;
   }
 
   .header__navigation--toggle {
     background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAxOSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5oYW1idXJnZXI8L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGcgaWQ9ImhhbWJ1cmdlciIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI+ICAgICAgICA8ZyBpZD0iR3JvdXAiIHN0cm9rZT0iIzQ5NEE1MiIgc3Ryb2tlLXdpZHRoPSIzIj4gICAgICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlIiB4PSIxLjUiIHk9IjEuNSIgd2lkdGg9IjIxIiBoZWlnaHQ9IjEiIHJ4PSIwLjUiPjwvcmVjdD4gICAgICAgICAgICA8cmVjdCBpZD0iUmVjdGFuZ2xlLUNvcHktNCIgeD0iMS41IiB5PSI5LjUiIHdpZHRoPSIyMSIgaGVpZ2h0PSIxIiByeD0iMC41Ij48L3JlY3Q+ICAgICAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZS1Db3B5LTUiIHg9IjEuNSIgeT0iMTcuNSIgd2lkdGg9IjIxIiBoZWlnaHQ9IjEiIHJ4PSIwLjUiPjwvcmVjdD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==);
-    background-position: top left;
-    background-repeat: no-repeat;
     background-size: cover;
-    cursor: pointer;
     height: 25px;
     width: 25px;
   }
@@ -350,47 +382,6 @@
     content: "Language";
   }
 
-  .header__language-switcher {
-    border-top: 2px solid #CED4DB;
-    padding-left: 30px;
-    padding-right: 0;
-  }
-
-  .header__language-switcher .lang_list_class {
-    background-color: inherit;
-    border: none;
-    border-radius: 0;
-    box-shadow: unset;
-    display: block;
-    left: 30px;
-    opacity: 1;
-    padding: 0 30px;
-    top: 0;
-    visibility: visible;
-  }
-
-  .header__language-switcher .lang_list_class li {
-    background-color: inherit;
-    font-size: 22px;
-  }
-
-  .header__language-switcher--label-current {
-    display: none;
-  }
-
-  .header__language-switcher .globe_class {
-    background-image: none;
-  }
-
-  .header__language-switcher .lang_list_class li:hover {
-    background-color: inherit;
-  }
-
-  .header__language-switcher .lang_list_class:before,
-  .header__language-switcher .lang_list_class:after {
-    content: none;
-  }
-
   .header__search--toggle {
     background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c3ZnIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5TZWFyY2g8L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+ICAgICAgICA8cGF0aCBkPSJNOS4xMzg2MTUzNCwxNS44OTI1Njg1IEM1LjQxMzk1NzQyLDE1Ljg5MjU2ODUgMi4zODM4ODUyNywxMi44NjM0NDc1IDIuMzgzODg1MjcsOS4xMzkwMDM3NiBDMi4zODM4ODUyNyw1LjQxNDU2MDA1IDUuNDEzOTU3NDIsMi4zODM4ODUyNyA5LjEzODYxNTM0LDIuMzgzODg1MjcgQzEyLjg2MzI3MzMsMi4zODM4ODUyNyAxNS44OTI1Njg1LDUuNDE0NTYwMDUgMTUuODkyNTY4NSw5LjEzOTAwMzc2IEMxNS44OTI1Njg1LDEyLjg2MzQ0NzUgMTIuODYzMjczMywxNS44OTI1Njg1IDkuMTM4NjE1MzQsMTUuODkyNTY4NSBNOS4xMzg3NTI0NSwyLjQzMzYwODg3ZS0xMyBDMTQuMTc3OTk1NSwyLjQzMzYwODg3ZS0xMyAxOC4yNzY0NTM3LDQuMTAwMzI0NzEgMTguMjc2NDUzNyw5LjEzOTI3Nzk2IEMxOC4yNzY0NTM3LDExLjIyOTgyMTEgMTcuNTcxMDE2OSwxMy4xNTg0NDM0IDE2LjM4NTYzMTMsMTQuNjk5NjY5NiBMMjMuNjUwODg4MSwyMS45NjUyMjY2IEMyNC4xMTYzNzA2LDIyLjQzMDcwOTIgMjQuMTE2MzcwNiwyMy4xODU0MDU1IDIzLjY1MDg4ODEsMjMuNjUwODg4MSBDMjMuMTg1NDA1NSwyNC4xMTYzNzA2IDIyLjQzMDcwOTIsMjQuMTE2MzcwNiAyMS45NjUyMjY2LDIzLjY1MDg4ODEgTDE0LjY5OTgxMzMsMTYuMzg1NDcxMyBDMTMuMTU4NDQwNSwxNy41NzA5NTA5IDExLjIyOTU3MzgsMTguMjc2NDUzNyA5LjEzODc1MjQ1LDE4LjI3NjQ1MzcgQzQuMDk5NTA5MzgsMTguMjc2NDUzNyAtMy43MzAzNDkzNmUtMTQsMTQuMTc4MjMxMiAtMy43MzAzNDkzNmUtMTQsOS4xMzkyNzc5NiBDLTMuNzMwMzQ5MzZlLTE0LDQuMTAwMzI0NzEgNC4wOTk1MDkzOCwyLjQzMzYwODg3ZS0xMyA5LjEzODc1MjQ1LDIuNDMzNjA4ODdlLTEzIFoiIGlkPSJwYXRoLTEiPjwvcGF0aD4gICAgPC9kZWZzPiAgICA8ZyBpZD0iU2VhcmNoIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4gICAgICAgIDxtYXNrIGlkPSJtYXNrLTIiIGZpbGw9IndoaXRlIj4gICAgICAgICAgICA8dXNlIHhsaW5rOmhyZWY9IiNwYXRoLTEiPjwvdXNlPiAgICAgICAgPC9tYXNrPiAgICAgICAgPHVzZSBpZD0iSWNvbnMvQWN0aW9ucy9TZWFyY2giIGZpbGw9IiM0OTRBNTIiIHhsaW5rOmhyZWY9IiNwYXRoLTEiPjwvdXNlPiAgICA8L2c+PC9zdmc+);
     background-size: cover;
@@ -400,20 +391,6 @@
 
   .header__search--toggle:after {
     content: "Search";
-  }
-
-  .header__search {
-    border-top: 2px solid #CED4DB;
-    order: 1;
-    padding: 30px;
-  }
-
-  .header__search .hs-search-field__input {
-    padding-left: 15px;
-  }
-
-  .header__search .hs-search-field__suggestions li {
-    padding: 10px 0;
   }
 
   .header__close--toggle {

--- a/src/css/elements/_buttons.css
+++ b/src/css/elements/_buttons.css
@@ -3,16 +3,9 @@ button,
   cursor: pointer;
   display: inline-block;
   font-size: 0.92rem;
-  font-weight: normal;
-  height: auto;
-  line-height: 1.1;
-  margin: 0;
-  position: relative;
   text-align: center;
-  text-decoration: none;
   transition: all 0.15s linear;
   white-space: normal;
-  width: auto;
 }
 
 button:disabled,

--- a/src/css/elements/_forms.css
+++ b/src/css/elements/_forms.css
@@ -124,7 +124,7 @@ form .hs-richtext img {
 /* Validation */
 
 .hs-form-required {
-  color: 	#EF6B51;
+  color: #EF6B51;
 }
 
 .hs-input.invalid.error {

--- a/src/css/elements/_forms.css
+++ b/src/css/elements/_forms.css
@@ -1,4 +1,4 @@
-/* Form */
+/* Form fields */
 
 .hs-form-field {
   margin-bottom: 1.4rem;
@@ -9,10 +9,7 @@
 form label {
   display: block;
   font-size: 0.875rem;
-  padding-top: 0;
   margin-bottom: 0.35rem;
-  text-align: left;
-  width: auto;
 }
 
 /* Help text - legends */
@@ -23,18 +20,14 @@ form legend {
 
 /* Inputs */
 
-.input {
-  position: relative;
-}
-
-input[type=text],
-input[type=email],
-input[type=password],
-input[type=tel],
-input[type=number],
-input[type=file],
-select,
-textarea {
+form input[type=text],
+form input[type=email],
+form input[type=password],
+form input[type=tel],
+form input[type=number],
+form input[type=file],
+form select,
+form textarea {
   background-color: #FFF;
   border: 2px solid;
   border-radius: 3px;
@@ -44,7 +37,7 @@ textarea {
   width: 100%;
 }
 
-fieldset {
+form fieldset {
   max-width: 100% !important;
 }
 
@@ -56,37 +49,32 @@ form .inputs-list {
   list-style: none;
 }
 
-.inputs-list > li {
+form .inputs-list > li {
   display: block;
   margin: 0.7rem 0;
-  padding: 0;
-  width: 100%;
 }
 
-.inputs-list input,
-.inputs-list span {
-  font-size: 0.875rem;
+form .inputs-list input,
+form .inputs-list span {
   vertical-align: middle;
 }
 
-.hs-input[type=checkbox],
-.hs-input[type=radio] {
-  border: none;
+form input[type=checkbox],
+form input[type=radio] {
   cursor: pointer;
-  height: auto;
-  line-height: normal;
   margin-right: 0.35rem;
-  padding: 0;
-  width: auto;
 }
 
 /* Inputs - datepicker */
 
-.hs-fieldtype-date .input .hs-dateinput:before {
-  color: #33475B;
+.hs-dateinput {
+  position: relative;
+}
+
+.hs-dateinput:before {
   content:'\01F4C5';
   position: absolute;
-  right: 10px;
+  right: 10%;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -100,18 +88,17 @@ form .inputs-list {
   box-shadow: none;
 }
 
-.fn-date-picker td .pika-button:hover {
+.fn-date-picker td .pika-button:hover,
+.fn-date-picker td .pika-button:focus {
   border-radius: 0 !important;
   color: #FFF;
 }
 
 /* Inputs - file picker */
 
-input[type=file] {
+form input[type=file] {
   background-color: transparent;
   border: initial;
-  box-shadow: none;
-  line-height: initial;
   padding: initial;
 }
 
@@ -127,23 +114,17 @@ form .hs-richtext img {
   max-width: 100% !important;
 }
 
-form .header {
-  background-color: transparent;
-  border: none;
-}
-
 /* GDPR */
 
 .legal-consent-container .hs-form-booleancheckbox-display > span,
 .legal-consent-container .hs-form-booleancheckbox-display > span p {
-  font-size: 0.875rem;
   margin-left: 1rem !important;
 }
 
 /* Validation */
 
 .hs-form-required {
-  color: red;
+  color: 	#EF6B51;
 }
 
 .hs-input.invalid.error {
@@ -162,18 +143,9 @@ form .hs-button {
   cursor: pointer;
   display: inline-block;
   font-size: 0.92rem;
-  font-weight: normal;
-  height: auto;
-  line-height: 1.1;
-  margin: 0;
-  position: relative;
   text-align: center;
-/* default "Get Free Widget" form (renders when no form is passed to the form HubL tag) is an anchor (a.hs-button) rather than a real input, so it needs explcit css to avoid link styling */
-  text-decoration: none;
   transition: all 0.15s linear;
   white-space: normal;
-  width: auto;
-  word-break: break-word;
 }
 
 /* Captcha */

--- a/src/css/elements/_tables.css
+++ b/src/css/elements/_tables.css
@@ -6,10 +6,6 @@ table {
   overflow-wrap: break-word;
 }
 
-tbody + tbody {
-  border-top: 2px solid;
-}
-
 /* Table Cells */
 
 th,

--- a/src/css/elements/_typography.css
+++ b/src/css/elements/_typography.css
@@ -17,10 +17,6 @@ p {
   margin: 0 0 1.4rem;
 }
 
-strong {
-  font-weight: 700;
-}
-
 /* Anchors */
 
 a {
@@ -28,7 +24,8 @@ a {
   text-decoration: none;
 }
 
-a:hover, a:focus {
+a:hover,
+a:focus {
   text-decoration: underline;
 }
 
@@ -82,22 +79,4 @@ hr {
   border: none;
   color: #CCC;
   height: 1px;
-}
-
-/* Subscripts and superscripts */
-
-sup,
-sub {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-sup {
-  top: -0.5em;
-}
-
-sub {
-  bottom: -0.25em;
 }

--- a/src/css/fallback.css
+++ b/src/css/fallback.css
@@ -140,7 +140,7 @@ form,
   font-family: Lato, sans-serif;
 }
 
-h3.form-title {
+.form-title {
   background-color: #494A52;
   color: #F8FAFC;
 }
@@ -153,26 +153,26 @@ form legend {
   color: #494A52;
 }
 
-input[type=text],
-input[type=email],
-input[type=password],
-input[type=tel],
-input[type=number],
-input[type=file],
-select,
-textarea {
+form input[type=text],
+form input[type=email],
+form input[type=password],
+form input[type=tel],
+form input[type=number],
+form input[type=file],
+form select,
+form textarea {
   border-color: #D1D6DC;
   color: #494A52;
 }
 
-input[type=text]:focus,
-input[type=email]:focus,
-input[type=password]:focus,
-input[type=tel]:focus,
-input[type=number]:focus,
-input[type=file]:focus,
-select:focus,
-textarea:focus {
+form input[type=text]:focus,
+form input[type=email]:focus,
+form input[type=password]:focus,
+form input[type=tel]:focus,
+form input[type=number]:focus,
+form input[type=file]:focus,
+form select:focus,
+form textarea:focus {
   border-color: #494A52;
 }
 
@@ -283,8 +283,8 @@ body .navigation-primary a:focus,
 }
 
 body .navigation-primary a:active,
-body .header__language-switcher-label-current:active,
-body .header__language-switcher .lang_list_class li a:active {
+.header__language-switcher-label-current:active,
+.header__language-switcher .lang_list_class li a:active {
   color: #71727A;
 }
 
@@ -293,7 +293,7 @@ body .navigation-primary .submenu.level-1 > li > a.active-item:after {
 }
 
 body .submenu.level-2,
-body .header__language-switcher .lang_list_class {
+.header__language-switcher .lang_list_class {
   background-color: #F8FAFC;
   border-color: #494A52;
 }
@@ -302,13 +302,13 @@ body .submenu.level-2 > li:first-child:before {
   border-color: #494A52;
 }
 
-body .header__language-switcher .lang_list_class:before {
+.header__language-switcher .lang_list_class:before {
   border-bottom-color: #494A52;
 }
 
 body .submenu.level-2 .menu-item .menu-link:hover,
 body .submenu.level-2 .menu-item .menu-link:focus,
-body .header__language-switcher .lang_list_class li:hover,
+.header__language-switcher .lang_list_class li:hover,
 body .submenu.level-2 > li:first-child:hover:before,
 body .submenu.level-2 > li:first-child.focus:before {
   background-color: #F8FAFC;
@@ -345,16 +345,7 @@ body .submenu.level-2 > li:first-child.focus:before {
   background-color: #F8FAFC;
 }
 
-.footer h1,
-.footer h2,
-.footer h3,
-.footer h4,
-.footer h5,
-.footer h6,
-.footer p,
-.footer a,
-.footer div,
-.footer span {
+.footer * {
   color: #494A52;
 }
 
@@ -362,39 +353,33 @@ body .submenu.level-2 > li:first-child.focus:before {
 /***************** Blog ******************/
 /*****************************************/
 
+.blog-index,
+.blog-post,
+.blog-header__inner,
+.blog-related-posts {
+  padding: 80px 0;
+}
+
+.blog-pagination,
+.blog-comments {
+  margin-bottom: 80px;
+}
+
 .blog-post__date {
   border-color: #494A52;
 }
 
-.blog-tag-filter__menu-link,
-.blog-post__tag-link,.blog-card__tag-link,
-.blog-post__author-name,.blog-card__title a {
+.blog-post__tag-link {
   color: #494A52;
 }
 
-.blog-card__tag-link:hover,
-.blog-card__title a:hover,
-.blog-tag-filter__menu-link:hover,
 .blog-post__tag-link:hover,
-.blog-post__author-name:hover,
-.blog-card__tag-link:focus,
-.blog-card__title a:focus,
-.blog-tag-filter__menu-link:focus,
-.blog-post__tag-link:focus,
-.blog-post__author-name:focus {
+.blog-post__tag-link:focus {
   color: #21222A;
 }
 
-.blog-card__tag-link:active,
-.blog-card__title a:active,
-.blog-tag-filter__menu-link:active,
-.blog-post__tag-link:active,
-.blog-post__author-name:active {
+.blog-post__tag-link:active {
   color: #71727A;
-}
-
-.blog-tag-filter__menu-link--active-item:after {
-  background-color: #494A52;
 }
 
 .blog-pagination__link {

--- a/src/css/templates/_blog.css
+++ b/src/css/templates/_blog.css
@@ -8,15 +8,6 @@
 .blog-header__inner {
   margin: 0 auto;
   max-width: 600px;
-  padding: 3.3rem 0;
-}
-
-.blog-header__title {
-  font-size: 2rem;
-}
-
-.blog-header__subtitle {
-  margin: 1rem 0 2rem;
 }
 
 .blog-header__form {
@@ -37,7 +28,7 @@
   box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.15);
   display: block;
   height: auto;
-  margin: 0 auto 1.5rem;
+  margin: 0 auto 1.4rem;
   width: 200px;
 }
 
@@ -51,7 +42,8 @@
   width: 40px;
 }
 
-.blog-header__author-social-links a:hover {
+.blog-header__author-social-links a:hover,
+.blog-header__author-social-links a:focus {
   background-color: #494A52;
 }
 
@@ -70,43 +62,23 @@
 .blog-index {
   display: flex;
   flex-wrap: wrap;
-  padding: 3.3rem 0;
-}
-
-.blog-index:after {
-  content: "";
-  flex: auto;
-}
-
-.blog-index__tag-header {
-  flex: 1 0 100%;
-  padding: 1rem;
-}
-
-.blog-index__tag-subtitle {
-  font-size: 1.16rem;
-  line-height: 1.1;
-}
-
-.blog-index__tag-heading {
-  border-bottom: 3px solid #D1D6DC;
-  padding-bottom: 1rem;
+  padding: 80px 0;
 }
 
 .blog-index__post {
-  flex:  0 0 100%;
+  flex: 0 0 100%;
   padding: 1rem;
 }
 
 @media screen and (min-width: 768px) {
   .blog-index__post {
-    flex:  0 0 calc(100%/2);
+    flex: 0 0 calc(100%/2);
   }
 }
 
 @media screen and (min-width: 1000px) {
   .blog-index__post {
-    flex:  0 0 calc(100%/3);
+    flex: 0 0 calc(100%/3);
   }
 }
 
@@ -114,7 +86,6 @@
   .blog-index__post--large {
     display: flex;
     flex: 1 0 100%;
-    justify-items: space-between;
   }
 }
 
@@ -140,15 +111,11 @@
 }
 
 .blog-index__post-content h2 {
-  margin: 0.5rem 0;
+  margin: 0.7rem 0;
 }
 
 .blog-index__post-content--small h2 {
   font-size: 1.25rem;
-}
-
-.blog-index__post-content p {
-  font-family: Lato, sans-serif;
 }
 
 .blog-index__post-content a {
@@ -158,18 +125,13 @@
 /* Blog pagination */
 
 .blog-pagination {
-  align-items: center;
   display: flex;
-  font-family: Lato, sans-serif;
   justify-content: center;
-  margin-bottom: 3.3rem;
-  text-align: center;
 }
 
 .blog-pagination__link {
   border: 2px solid transparent;
   border-radius: 7px;
-  display: inline-flex;
   line-height: 1;
   margin: 0 0.1rem;
   padding: 0.25rem 0.4rem;
@@ -177,7 +139,7 @@
 }
 
 .blog-pagination__link--active {
-  border: 2px solid #B0C1D4;
+  border-color: #B0C1D4;
 }
 
 .blog-pagination__link:hover,
@@ -185,24 +147,16 @@
   text-decoration: none;
 }
 
-.blog-pagination__prev-link,
-.blog-pagination__next-link {
-  align-items: center;
-  display: inline-flex;
-}
-
 .blog-pagination__prev-link {
   margin-right: 0.25rem;
-  text-align: right;
 }
 
 .blog-pagination__next-link {
   margin-left: 0.25rem;
-  text-align: left;
 }
 
-.blog-pagination__prev-link--disabled,
-.blog-pagination__next-link--disabled {
+.blog-pagination__link.blog-pagination__prev-link--disabled,
+.blog-pagination__link.blog-pagination__next-link--disabled {
   color: #B0C1D4;
   cursor: default;
   pointer-events: none;
@@ -211,7 +165,7 @@
 .blog-pagination__prev-link svg,
 .blog-pagination__next-link svg {
   fill: #494A52;
-  margin: 0 5px;
+  margin: 0 0.3rem;
 }
 
 .blog-pagination__prev-link--disabled svg,
@@ -229,25 +183,15 @@
 .blog-post {
   margin: 0 auto;
   max-width: 960px;
-  padding: 3.3rem 0;
-}
-
-.blog-post h1 {
-  font-size: 1.6rem;
 }
 
 .blog-post__meta {
-  margin: 1rem 0;
+  margin-bottom: 1.4rem;
 }
 
 .blog-post__meta a {
   color: #494A52;
   text-decoration: underline;
-}
-
-.blog-post__tags {
-  color: #000;
-  font-family: Lato, sans-serif;
 }
 
 .blog-post__tags svg {
@@ -257,16 +201,13 @@
 }
 
 .blog-post__tag-link {
-  color: #000;
-  font-size: .8rem;
+  font-size: 0.875rem;
 }
 
 /* Blog related posts */
 
 .blog-related-posts {
   background-color: #F8FAFC;
-  margin-top: 3rem;
-  padding: 2rem 0;
 }
 
 .blog-related-posts h2 {
@@ -279,8 +220,6 @@
 }
 
 .blog-related-posts__post {
-  color: #494A52;
-  display: block;
   flex: 0 0 100%;
   padding: 1rem;
 }
@@ -303,7 +242,7 @@
 }
 
 .blog-related-posts__title {
-  margin: 1rem 0 0.5rem;
+  margin: 0.7rem 0;
 }
 
 .blog-related-posts__title a {
@@ -317,30 +256,16 @@
   max-width: 680px;
 }
 
-.blog-comments form {
-  max-width: 100%;
-}
-
 .blog-comments .hs-submit {
   text-align: center;
-}
-
-.blog-comments .hs-button {
-  background-color: transparent;
-  border: 2px solid #494A52;
-  color: #494A52;
-}
-
-.blog-comments .hs-button:hover {
-  background-color: #494A52;
-  color: #FFF;
 }
 
 .blog-comments .comment-reply-to {
   border: 0 none;
 }
 
-.blog-comments .comment-reply-to:hover {
+.blog-comments .comment-reply-to:hover,
+.blog-comments .comment-reply-to:focus {
   background-color: transparent;
   text-decoration: underline;
 }

--- a/src/css/templates/_system.css
+++ b/src/css/templates/_system.css
@@ -9,7 +9,6 @@
 .error-page:before {
   color: #F3F6F9;
   content: attr(data-error);
-  font-family: Lato, sans-serif;
   font-size: 40vw;
   font-weight: bold;
   left: 50%;
@@ -49,32 +48,7 @@
   max-width: 100%;
 }
 
-#email-prefs-form .header {
-  background-color: transparent;
-}
-
 /* Search pages */
-
-.hs-search-field__bar {
-  position: relative;
-}
-
-.hs-search-field__suggestions {
-  background-color: #FFF;
-  max-width: 360px;
-  position: absolute;
-  right: 0;
-  top: 100%;
-  width: 100%;
-}
-
-.hs-search-results {
-  margin-top: 1.4rem;
-}
-
-ul.hs-search-results__listing li {
-  margin-bottom: 1.4rem;
-}
 
 .hs-search-results__title {
   color: #494A52;
@@ -92,18 +66,9 @@ ul.hs-search-results__listing li {
   padding-top: 0.7rem;
 }
 
-.hs-search-highlight {
-  font-weight: bold;
-}
-
-.hs-search-results__pagination a {
-  color: #0270E0;
-}
-
 /* Password prompt */
 
 .password-prompt input[type=password] {
-  display: block;
   height: auto !important;
   margin-bottom: 1.4rem;
 }
@@ -115,6 +80,7 @@ ul.hs-search-results__listing li {
 }
 
 .backup-unsubscribe input[type=email] {
+  font-size: 0.875rem !important;
   margin-bottom: 1.4rem;
   padding: 0.7rem !important;
 }

--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -231,7 +231,7 @@ form,
 
 /* Form title */
 
-h3.form-title {
+.form-title {
   background-color: {{ form_title_bg_color }};
   color: {{ form_title_font_color }};
 }
@@ -250,30 +250,34 @@ form legend {
 
 /* Form inputs */
 
-input[type=text],
-input[type=email],
-input[type=password],
-input[type=tel],
-input[type=number],
-input[type=file],
-select,
-textarea {
+form input[type=text],
+form input[type=email],
+form input[type=password],
+form input[type=tel],
+form input[type=number],
+form input[type=file],
+form select,
+form textarea {
   border-color: {{ form_input_border_color }};
   color: {{ body_font.color }};
 }
 
-input[type=text]:focus,
-input[type=email]:focus,
-input[type=password]:focus,
-input[type=tel]:focus,
-input[type=number]:focus,
-input[type=file]:focus,
-select:focus,
-textarea:focus {
+form input[type=text]:focus,
+form input[type=email]:focus,
+form input[type=password]:focus,
+form input[type=tel]:focus,
+form input[type=number]:focus,
+form input[type=file]:focus,
+form select:focus,
+form textarea:focus {
   border-color: {{ form_input_focus_border_color }};
 }
 
 /* Form placeholder text */
+
+::-webkit-input-placeholder {
+  color: {{ body_font.color }};
+}
 
 ::-webkit-input-placeholder,
 ::-moz-placeholder,
@@ -352,10 +356,6 @@ tfoot td {
   color: {{ table_footer_font_color }};
 }
 
-tbody + tbody {
-  border-top-color: {{ table_border_color }};
-}
-
 {###########################################################################}
 {###########################   7. Site header   ############################}
 {###########################################################################}
@@ -382,8 +382,8 @@ body .navigation-primary a:focus,
 }
 
 body .navigation-primary a:active,
-body .header__language-switcher-label-current:active,
-body .header__language-switcher .lang_list_class li a:active {
+.header__language-switcher-label-current:active,
+.header__language-switcher .lang_list_class li a:active {
   color: {{ color_variant(header_nav_link_color, 40) }};
 }
 
@@ -392,7 +392,7 @@ body .navigation-primary .submenu.level-1 > li > a.active-item:after {
 }
 
 body .submenu.level-2,
-body .header__language-switcher .lang_list_class {
+.header__language-switcher .lang_list_class {
   background-color: {{ header_bg_color }};
   border-color: {{ header_child_nav_border_color }};
 }
@@ -401,13 +401,13 @@ body .submenu.level-2 > li:first-child:before {
   border-color: {{ header_child_nav_border_color }};
 }
 
-body .header__language-switcher .lang_list_class:before {
+.header__language-switcher .lang_list_class:before {
   border-bottom-color: {{ header_child_nav_border_color }};
 }
 
 body .submenu.level-2 .menu-item .menu-link:hover,
 body .submenu.level-2 .menu-item .menu-link:focus,
-body .header__language-switcher .lang_list_class li:hover,
+.header__language-switcher .lang_list_class li:hover,
 body .submenu.level-2 > li:first-child:hover:before,
 body .submenu.level-2 > li:first-child.focus:before {
   background-color: {{ header_bg_color }};
@@ -447,16 +447,7 @@ body .submenu.level-2 > li:first-child.focus:before {
 
 /* Footer Content */
 
-.footer h1,
-.footer h2,
-.footer h3,
-.footer h4,
-.footer h5,
-.footer h6
-.footer p,
-.footer a,
-.footer div,
-.footer span {
+.footer * {
   color: {{ footer_font_color }};
 }
 
@@ -464,41 +455,33 @@ body .submenu.level-2 > li:first-child.focus:before {
 {##############################   9. Blog   ################################}
 {###########################################################################}
 
+.blog-index,
+.blog-post,
+.blog-header__inner,
+.blog-related-posts {
+  padding: {{ theme.spacing.vertical_spacing }}px 0;
+}
+
+.blog-pagination,
+.blog-comments {
+  margin-bottom: {{ theme.spacing.vertical_spacing }}px;
+}
+
 .blog-post__date {
   border-color: {{ body_font.color }};
 }
 
-.blog-tag-filter__menu-link,
-.blog-post__tag-link,
-.blog-card__tag-link,
-.blog-post__author-name,
-.blog-card__title a {
+.blog-post__tag-link {
   color: {{ body_font.color }};
 }
 
-.blog-card__tag-link:hover,
-.blog-card__title a:hover,
-.blog-tag-filter__menu-link:hover,
 .blog-post__tag-link:hover,
-.blog-post__author-name:hover,
-.blog-card__tag-link:focus,
-.blog-card__title a:focus,
-.blog-tag-filter__menu-link:focus,
-.blog-post__tag-link:focus,
-.blog-post__author-name:focus {
+.blog-post__tag-link:focus {
   color: {{ color_variant(body_font.color, -40) }};
 }
 
-.blog-card__tag-link:active,
-.blog-card__title a:active,
-.blog-tag-filter__menu-link:active,
-.blog-post__tag-link:active,
-.blog-post__author-name:active {
+.blog-post__tag-link:active {
   color: {{ color_variant(body_font.color, 40) }};
-}
-
-.blog-tag-filter__menu-link--active-item:after {
-  background-color: {{ primary_color }};
 }
 
 .blog-pagination__link {
@@ -509,16 +492,6 @@ body .submenu.level-2 > li:first-child.focus:before {
 .blog-pagination__prev-link:after,
 .blog-pagination__next-link:after {
   background-color: {{ primary_color }};
-}
-
-.blog-post__title {
-  {{ heading_two.style }};
-  color: {{ heading_two.color }};
-  font-size: {{ heading_two.size ~ heading_two.size_unit }};
-}
-
-.blog-post__author {
-  background-color: {{ secondary_color }};
 }
 
 #comments-listing .comment-reply-to {


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

- Removes unused or redundant CSS from the boilerplate style-sheets (duplicate CSS, CSS that isn't used, removing old selectors, consolidating selectors, etc.) 
- Rearranges some CSS in the header.css file so it is organized in a more logical way (e.g. grouping media queries under specified style vs. at the bottom of the style-sheet per https://github.com/HubSpot/cms-theme-boilerplate/blob/main/STYLEGUIDE.md#css-code-formatting # 14)

There are very little visual style differences with this update. The visual changes include: 
- Changing some of the blog elements spacing to be tied to the theme's vertical spacing setting in theme-overrides
- The search field border getting increased from 1.79px to 2px 
- Some very minor spacing changes so that the vertical rhythm lined up with the technique described here (https://github.com/HubSpot/cms-theme-boilerplate/blob/main/STYLEGUIDE.md#vertical-rhythm)
- Removal of the `tbody + tbody` selector from `tables.css`. It is highly unlikely this would be used on a site. 

The purpose of the PR is to remove unnecessary CSS which will have a slight performance benefit, will make the boilerplate easier to read through, and reduces the amount of things a developer needs to remove when getting started with boilerplate.

**Relevant links**

Fixes #288 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
