### PR TITLE
Updating default pricing button text to add context for screen readers

### DIFF
--- a/src/templates/pricing.html
+++ b/src/templates/pricing.html
@@ -31,7 +31,7 @@
       }
     %}
       {% dnd_module path='../modules/pricing-card',
-        button_text='Buy starter now',
+        button_text='Buy starter',
         description='For individuals or team just getting started with sales.',
         features=[
           'Ad management',
@@ -52,7 +52,7 @@
       %}
       {% end_dnd_module %}
       {% dnd_module path='../modules/pricing-card',
-        button_text='Buy professional now',
+        button_text='Buy professional',
         description='For teams that need to create sales plans with confidence.',
         features=[
           'Marketing automation',
@@ -73,7 +73,7 @@
       %}
       {% end_dnd_module %}
       {% dnd_module path='../modules/pricing-card',
-        button_text='Buy enterprise now',
+        button_text='Buy enterprise',
         description='For teams that need additional security, control, and support.',
         features=[
           'Content partitioning',

--- a/src/templates/pricing.html
+++ b/src/templates/pricing.html
@@ -31,7 +31,7 @@
       }
     %}
       {% dnd_module path='../modules/pricing-card',
-        button_text='Buy now',
+        button_text='Buy starter now',
         description='For individuals or team just getting started with sales.',
         features=[
           'Ad management',
@@ -52,7 +52,7 @@
       %}
       {% end_dnd_module %}
       {% dnd_module path='../modules/pricing-card',
-        button_text='Buy now',
+        button_text='Buy professional now',
         description='For teams that need to create sales plans with confidence.',
         features=[
           'Marketing automation',
@@ -73,7 +73,7 @@
       %}
       {% end_dnd_module %}
       {% dnd_module path='../modules/pricing-card',
-        button_text='Buy now',
+        button_text='Buy enterprise now',
         description='For teams that need additional security, control, and support.',
         features=[
           'Content partitioning',


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Updated the default button text on the pricing template to add context for screen readers. The default button pricing module button text is "Sign up for free" so that should have enough context by default. I'll also be updating the boilerplate demo website to reflect these changes. 

**Relevant links**

Fixes #300

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
