### PR TITLE
Update language switcher conditional to account for blog posts without translations

### DIFF
--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -43,7 +43,7 @@
       {# Header navigation row two #}
       <div class="header__row-2">
         <div class="header--toggle header__navigation--toggle"></div>
-        {% if content.translated_content|length || group.translations %}
+        {% if content.translated_content|length || is_listing_view && group.translations %}
           <div class="header--toggle header__language-switcher--toggle"></div>
         {% endif %}
         <div class="header--toggle header__search--toggle"></div>

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -19,7 +19,7 @@
 
       {# Header navigation row one #}
       <div class="header__row-1">
-        {% if content.translated_content|length || group.translations %}
+        {% if content.translated_content|length || is_listing_view && group.translations %}
           <div class="header__language-switcher header--element">
             <div class="header__language-switcher--label">
               {% module 'language-switcher' path='@hubspot/language_switcher',


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Currently the conditional around the language switcher in the `header.html` file accounts for translations on pages, blog posts, and blog listing. However, it doesn't account for if a blog listing has translated content but a blog post on the blog doesn't. This update to the conditional should account for that. 

**Relevant links**

Example blog listing with translated content:http://jrosa-102019231.hs-sitesqa.com/blog
Example blog post with translated content on that blog: http://jrosa-102019231.hs-sitesqa.com/blog/toy-story-4
Example blog post without translated content on that blog: http://jrosa-102019231.hs-sitesqa.com/blog/test-blog-post-0-0-0-0-0

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.