### PR TITLE
add aria menu, aria none, and aria labels to items in nav

### DIFF
--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -54,8 +54,8 @@
 {# Navigation menu item macro #}
 
 {% macro link(node) %}
-  <li {{ childClasses() if node.children else defaultItemClasses() }} aria-role="none">
-    <a href="{{ node.url if node.url else 'javascript:;' }}" class="menu-link" {{ activeBranch() if node.activeBranch }} {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }} aria-role="menuitem" {{' aria-haspopup="true" aria-expanded="false" ' if node.children }}>{{ node.label }}</a>
+  <li {{ childClasses() if node.children else defaultItemClasses() }} aria-role="none"  >
+    <a href="{{ node.url if node.url else 'javascript:;' }}" class="menu-link" {{ activeBranch() if node.activeBranch }} {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }} aria-role="menuitem" {{' aria-haspopup="true" aria-expanded="false" ' if node.children }} {%if level == 1 %}tabindex="0"{% endif %}>{{ node.label }}</a>
 
     {% if node.children %}
       <input type="checkbox" id="{{ node.label }}" class="submenu-toggle">

--- a/src/modules/menu-section.module/module.html
+++ b/src/modules/menu-section.module/module.html
@@ -54,8 +54,8 @@
 {# Navigation menu item macro #}
 
 {% macro link(node) %}
-  <li {{ childClasses() if node.children else defaultItemClasses() }}>
-    <a href="{{ node.url if node.url else 'javascript:;' }}" class="menu-link" {{ activeBranch() if node.activeBranch }} {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }}>{{ node.label }}</a>
+  <li {{ childClasses() if node.children else defaultItemClasses() }} aria-role="none">
+    <a href="{{ node.url if node.url else 'javascript:;' }}" class="menu-link" {{ activeBranch() if node.activeBranch }} {{ activeNode() if node.activeNode }} {{ linkTarget() if node.linkTarget }} aria-role="menuitem" {{' aria-haspopup="true" aria-expanded="false" ' if node.children }}>{{ node.label }}</a>
 
     {% if node.children %}
       <input type="checkbox" id="{{ node.label }}" class="submenu-toggle">
@@ -71,7 +71,7 @@
 
 {% macro renderNavigation(menuTree) %}
   {% set level = level + 1 %}
-  <ul class="submenu level-{{ level }}">
+  <ul class="submenu level-{{ level }}" {{'aria-role="menubar"' if level == 1 else 'aria-role="menu"'}} aria-label="{{menuTree.label}}">
     {% for node in menuTree.children %}
       {{ link(node) }}
     {% endfor %}


### PR DESCRIPTION
**Types of change**
- [x] Enhancement (change which improves upon an existing feature)


**Description**

Adding aria information to main menu. It's not that what we currently have is inaccessible, but there are some improvements that can be made.

These changes make it so screen readers understand when they're on a menu, submenu, etc. 


One aspect not accounted for yet but should be - flyouts/dropdowns should ideally open when keyboard navigated and not just always open. The situations could be worse though.

**Relevant links**
These updates are being made based on https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html

Example page: http://hubspot-developers-1ytr6xc-6333443.hs-sites.com/boilerplate-homepage
GitHub issue:

**Checklist**

- [ ] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ ] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @jmclaren and @ajlaporte -->
