### PR TITLE
Adding JS and styles for subscription preferences template disabled input

### DIFF
--- a/src/css/templates/_system.css
+++ b/src/css/templates/_system.css
@@ -84,3 +84,14 @@
   margin-bottom: 1.4rem;
   padding: 0.7rem !important;
 }
+
+/* Subscription preferences */
+
+#email-prefs-form .item.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+#email-prefs-form .item.disabled input:disabled {
+  cursor: not-allowed;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21,6 +21,7 @@
   var allElements = document.querySelectorAll(
     '.header--element, .header--toggle'
   );
+  var emailGlobalUnsub = document.querySelector('input[name="globalunsub"]');
 
   // Functions
 
@@ -78,6 +79,21 @@
     closeToggle.classList.remove('show');
   }
 
+  // Function to disable the other checkbox inputs on the email subscription system page template
+  function toggleDisabled() {
+    var emailSubItem = document.querySelector('.item');
+    var emailSubItemInput = emailSubItem.querySelector('input')
+    
+    if (emailGlobalUnsub.checked) {
+      emailSubItem.classList.add('disabled');
+      emailSubItemInput.setAttribute('disabled', 'disabled');
+      emailSubItemInput.checked = false;
+    } else {
+      emailSubItem.classList.remove('disabled');
+      emailSubItemInput.removeAttribute('disabled');
+    }
+  }
+
   // Execute JavaScript on document ready
   domReady(function () {
     if (!document.body) {
@@ -102,6 +118,11 @@
       // Function dependent on close toggle
       if (closeToggle) {
         closeToggle.addEventListener('click', closeAll);
+      }
+
+      // Function dependent on email unsubscribe from all input
+      if (emailGlobalUnsub) {
+        emailGlobalUnsub.addEventListener('change', toggleDisabled);
       }
 
     }


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adding in vanilla JS to the `main.js` file for the theme's system `subscription-preferences.html` template. This JS looks to see if the global unsubscribe input is on the document and then will add/remove some classes and attributes to the surrounding checkboxes on that preferences form in order to disable the input. There are some additional styles in place to make the rest of the text label for that checkbox look disabled as well.

**Relevant links**

GitHub issue: https://github.com/HubSpot/cms-theme-boilerplate/issues/147

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.
