### PR TITLE
Removing transitions from the mobile breakpoint in the menu

### DIFF
--- a/src/modules/menu-section.module/module.css
+++ b/src/modules/menu-section.module/module.css
@@ -268,6 +268,12 @@
 
   .submenu.level-2 > li:first-child:before {
     content: none;
+    transition: none;
+  }
+
+  .submenu.level-2 > li:first-child:hover:before,
+  .submenu.level-2 > li:first-child.focus:before {
+    transition: none;
   }
 
   input[type="checkbox"]:checked ~ .submenu {
@@ -299,6 +305,12 @@
 
   .submenu.level-2 .menu-item .menu-link {
     padding: 7px 60px;
+    transition: none;
+  }
+
+  .submenu.level-2 .menu-item .menu-link:hover,
+  .submenu.level-2 .menu-item .menu-link:focus {
+    transition: none;
   }
 
   .submenu.level-2 .menu-item .menu-link:hover {


### PR DESCRIPTION
**Types of change**

- [x] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Some of the default themes have had issues where the transitions in CSS are causing issues on the mobile breakpoint. This is only happening in the menu module and appears to be happening when theme settings are adjusted for the menu's background color. The transition on mobile isn't properly taking effect, so we've decided to remove the transition CSS on the mobile breakpoint only for background color.

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.
