### PR TITLE
Updates to system page styles

### DIFF
--- a/src/css/templates/_system.css
+++ b/src/css/templates/_system.css
@@ -33,6 +33,16 @@
   padding: 3rem 1.4rem;
 }
 
+.systems-page--search-results {
+  max-width: 100%;
+}
+
+.systems-page .header {
+  background-color: transparent;
+  border-bottom: none;
+  padding: 0;
+}
+
 .systems-page .success {
   background-color: #CDE3CC;
   border: 1.5px solid #4F7D24;
@@ -46,6 +56,11 @@
 
 .systems-page form input {
   max-width: 100%;
+}
+
+.systems-page form input[type='submit'] {
+  margin: .625rem 0;
+  display: block;
 }
 
 /* Search pages */
@@ -73,6 +88,17 @@
   margin-bottom: 1.4rem;
 }
 
+.systems-page #hs-login-widget-remember,
+.systems-page #hs-login-widget-remember ~ label {
+  display: inline-block;
+  margin-bottom: 3px;
+}
+
+.systems-page #hs_login_reset {
+  display: block;
+  margin-bottom: 0.625rem;
+}
+
 /* Backup unsubscribe */
 
 .backup-unsubscribe #email-prefs-form div {
@@ -94,4 +120,20 @@
 
 #email-prefs-form .item.disabled input:disabled {
   cursor: not-allowed;
+}
+
+/* Membership pages */
+#hs-membership-form a[class*='show-password'] {
+  font-size: 0.75rem;
+}
+
+/* Input error messages */
+
+.form-input-validation-message ul.hs-error-msgs {
+  padding-left: 0;
+  margin: 0;
+}
+
+.form-input-validation-message ul.hs-error-msgs li {
+  margin: 0;
 }

--- a/src/css/templates/_system.css
+++ b/src/css/templates/_system.css
@@ -59,7 +59,7 @@
 }
 
 .systems-page form input[type='submit'] {
-  margin: .625rem 0;
+  margin: 0.625rem 0;
   display: block;
 }
 

--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -14,7 +14,7 @@
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
-    <div class="systems-page">
+    <div class="systems-page systems-page--search-results">
       {% module_block module 'search_results_content'
         label='Search results heading',
         path='@hubspot/rich_text'


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Updating the system page templates so they are a bit cleaner looking. This PRs includes updates to the following:

- Remember me checkbox - Inlines the label next to the checkbox
- Show password text - make this a little smaller in font size
- Password pages error messaging - removes padding and margins around the `ul` and `li` so that messaging isn't bumped out in the form design
- Search results - now spans the full width of the container
- `.header` class restyled - this generic class was getting CSS from the header of the website, restyled this for system pages to remove the background color and other associated CSS bleeding over
- Submit inputs - Added some spacing/margin around these

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.
