### PR TITLE
Setting lazy for loading on applicable default image modules

### DIFF
--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -15,7 +15,7 @@
     {% dnd_section
       vertical_alignment='TOP'
     %}
-      {% dnd_module path='@hubspot/image',
+      {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Coworkers sitting together and smiling outside.',
           'size_type': 'auto',

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -68,7 +68,6 @@
       {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'loading': 'lazy',
           'size_type': 'auto',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -22,7 +22,7 @@
       },
       vertical_alignment='MIDDLE'
     %}
-      {% dnd_module path='@hubspot/image',
+      {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
           'size_type': 'auto',
@@ -65,9 +65,10 @@
           <p>Use text and images to tell your company’s story. Explain what makes your product or service extraordinary.</p>
         {% end_module_attribute %}
       {% end_dnd_module %}
-      {% dnd_module path='@hubspot/image',
+      {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+          'loading': 'lazy',
           'size_type': 'auto',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },
@@ -88,9 +89,10 @@
       },
       vertical_alignment='MIDDLE'
     %}
-      {% dnd_module path='@hubspot/image',
+      {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+          'loading': 'lazy',
           'size_type': 'auto',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },
@@ -191,6 +193,7 @@
           {% dnd_module path='@hubspot/linked_image',
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+              'loading': 'lazy',
               'size_type': 'auto',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
@@ -214,6 +217,7 @@
           {% dnd_module path='@hubspot/linked_image',
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+              'loading': 'lazy',
               'size_type': 'auto',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
@@ -237,6 +241,7 @@
           {% dnd_module path='@hubspot/linked_image',
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+              'loading': 'lazy',
               'size_type': 'auto',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }

--- a/src/templates/landing-page.html
+++ b/src/templates/landing-page.html
@@ -67,6 +67,7 @@
           {% dnd_module path='@hubspot/linked_image',
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+              'loading': 'lazy',
               'size_type': 'auto',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
@@ -90,6 +91,7 @@
           {% dnd_module path='@hubspot/linked_image',
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+              'loading': 'lazy',
               'size_type': 'auto',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
@@ -113,6 +115,7 @@
           {% dnd_module path='@hubspot/linked_image',
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+              'loading': 'lazy',
               'size_type': 'auto',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [X] New feature (change which adds new functionality)

**Description**

Getting default image modules set up with lazy loading in preparation for the lazy loading option being added to the default image module. Also changing over all `image` to `linked_image` to remain consistent. The images that were set to lazy were any images below the fold on the home page template and any images below the fold on the landing page template. Examples of both in my test portal can be seen below: 

[Landing page](http://jrosa-102019231.hs-sitesqa.com/-temporary-slug-b559582a-b74e-48e2-88cd-c73097fc1014?hs_preview=GGDvfuxc-4490949455)
[Home page](https://preview.hs-sitesqa.com/_hcms/preview/template/multi?domain=undefined&hs_preview_key=L909nLdOFi1fSwJBZC1MwA&portalId=102019231&tc_deviceCategory=undefined&template_file_path=boilerplate-theme/templates/home.html&updated=1612980932743)

The demo website has already been updated to use the lazy loading feature. 

**Relevant links**

Fixes #287 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
