### PR TITLE
Fix alt text

### DIFF
--- a/src/css/elements/_typography.css
+++ b/src/css/elements/_typography.css
@@ -80,3 +80,10 @@ hr {
   color: #CCC;
   height: 1px;
 }
+
+/* Image alt text */
+
+img {
+  font-size: 14px;
+  word-break: normal;
+}

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -17,11 +17,7 @@
         "resizable": true,
         "show_loading" : true,
         "default": {
-          "alt": "A blue puzzle piece",
-          "height": 32,
-          "loading" : "lazy",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "width": 35
+          "loading" : "lazy"
         }
       },
       {
@@ -55,11 +51,7 @@
     "default": [
       {
         "image": {
-          "alt": "A blue puzzle piece",
-          "height": 32,
-          "loading" : "lazy",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "width": 35
+          "loading" : "lazy"
         },
         "title": "This is a title",
         "title_heading_type": "h3",
@@ -67,11 +59,7 @@
       },
       {
         "image": {
-          "alt": "A blue puzzle piece",
-          "height": 32,
-          "loading" : "lazy",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "width": 35
+          "loading" : "lazy"
         },
         "title": "This is a title",
         "title_heading_type": "h3",
@@ -79,11 +67,7 @@
       },
       {
         "image": {
-          "alt": "A blue puzzle piece",
-          "height": 32,
-          "loading" : "lazy",
-          "src": "https://cdn2.hubspot.net/hubfs/1932631/Email_Templates/Prototype/services_7.png",
-          "width": 35
+          "loading" : "lazy"
         },
         "title": "This is a title",
         "title_heading_type": "h3",


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

We had an issue with alt text being hard to read. After investigating it looks like this happened when an image had a small width set and was within a parent with `display: flex`. We have `word-break: break all` set by default so the alt text was stacking one letter on top of another. We adjusted some styles for the image tag which should target the alt text and removed the broken image in the module (as it wasn't required for the module and we were setting it at the template level). 

**Relevant links**

Resolves #324 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
