### PR TITLE
Adding "default" as the default menu for the menu-section.module 

### DIFF
--- a/src/modules/menu-section.module/fields.json
+++ b/src/modules/menu-section.module/fields.json
@@ -2,6 +2,7 @@
   {
     "label": "Primary menu field",
     "name": "primary_menu_field",
-    "type": "menu"
+    "type": "menu",
+    "default": "default"
   }
 ]


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Previously, the menu field wouldn't accept a `"default"` value of `"default"` to allow for a customer's default menu in their portal to be the placeholder. This caused issues for setting default content because you could only let the menu field be unselected, or, we have noticed providers leaving in IDs for menus that don't exist on a customer's portal. Setting the param `"default": "default"` will now point to a customer's default menu (as long as they have one in their portal)

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.