### PR TITLE
Adding overflow on pre element to fix responsiveness issue

### DIFF
--- a/src/css/elements/_typography.css
+++ b/src/css/elements/_typography.css
@@ -111,6 +111,10 @@ ul.no-list {
 
 /* Code blocks */
 
+pre {
+  overflow: auto;
+}
+
 code {
   vertical-align: bottom;
 }


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds `overflow: auto` on the `pre` element to prevent responsiveness issues on mobile. In particular this was an issue on the boilerplate typography page and on the boilerplate `qa-test.html` template. 

**Relevant links**

Resolves #332 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
