### PR TITLE
Adding fields parameter and style guiding existing fields

### DIFF
--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -9,23 +9,29 @@
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area' class='body-container body-container--about', label='Main section' %}
+  {% dnd_area 'dnd_area'
+    label='Main section',
+    class='body-container body-container--about'
+  %}
 
     {# Main section #}
     {% dnd_section
       vertical_alignment='TOP'
     %}
       {% dnd_module path='@hubspot/linked_image',
-        img={
-          'alt': 'Coworkers sitting together and smiling outside.',
-          'size_type': 'auto',
-          'src': get_asset_url('../images/team-image.png')
+        fields={
+          img: {
+            'alt': 'Coworkers sitting together and smiling outside.',
+            'size_type': 'auto',
+            'src': get_asset_url('../images/team-image.png')
+          }
         },
         offset=0,
         width=6
       %}
       {% end_dnd_module %}
-      {% dnd_module path='@hubspot/rich_text',
+      {% dnd_module
+        path='@hubspot/rich_text',
         offset=6,
         width=6
       %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -88,8 +88,9 @@
           <h1 class="blog-header__title">{{ group.public_title }}</h1>
           <p class="blog-header__subtitle">{{ group.description }}</p>
           <div class="blog-header__form">
-            {% module "blog_subscribe_form" path="@hubspot/blog_subscribe",
-              title=""
+            {% module 'blog_subscribe_form'
+              path='@hubspot/blog_subscribe',
+              title=''
             %}
           </div>
         {% endif %}

--- a/src/templates/blog-post.html
+++ b/src/templates/blog-post.html
@@ -47,7 +47,7 @@
         <div class="blog-comments">
           {% module 'blog_comments'
             path='@hubspot/blog_comments',
-            label="Blog comments"
+            label='Blog comments'
           %}
         </div>
       {% endif %}
@@ -84,7 +84,7 @@
     {% related_blog_posts
       limit=3,
       no_wrapper=True,
-      post_formatter="related_posts"
+      post_formatter='related_posts'
     %}
     {# End recent posts listing #}
 

--- a/src/templates/contact.html
+++ b/src/templates/contact.html
@@ -9,7 +9,10 @@
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area' class='body-container body-container--contact', label='Main section' %}
+  {% dnd_area 'dnd_area'
+    label='Main section',
+    class='body-container body-container--contact'
+  %}
 
     {# Main section #}
     {% dnd_section
@@ -17,7 +20,8 @@
     %}
       {% dnd_column %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text'
+          {% dnd_module
+            path='@hubspot/rich_text',
             horizontal_alignment='CENTER'
           %}
             {% module_attribute 'html' %}
@@ -26,45 +30,48 @@
           {% end_dnd_module %}
         {% end_dnd_row %}
         {% dnd_row %}
-          {% dnd_module path='../modules/card-section',
-            card=[
-              {
-                'image': {
-                  'alt': 'Phone number',
-                  'height': 230,
-                  'loading': 'disabled',
-                  'src': get_asset_url('../images/phone.png'),
-                  'width': 230
+          {% dnd_module
+            path='../modules/card-section',
+            fields={
+              card: [
+                {
+                  'image': {
+                    'alt': 'Phone number',
+                    'height': 230,
+                    'loading': 'disabled',
+                    'src': get_asset_url('../images/phone.png'),
+                    'width': 230
+                  },
+                  'text': '(887) 929-0687',
+                  'title': '',
+                  'title_heading_type': 'h2'
                 },
-                'text': '(887) 929-0687',
-                'title': '',
-                'title_heading_type': 'h2'
-              },
-              {
-                'image': {
-                  'alt': 'Email',
-                  'height': 230,
-                  'loading': 'disabled',
-                  'src': get_asset_url('../images/email.png'),
-                  'width': 230
+                {
+                  'image': {
+                    'alt': 'Email',
+                    'height': 230,
+                    'loading': 'disabled',
+                    'src': get_asset_url('../images/email.png'),
+                    'width': 230
+                  },
+                  'text': 'contact@business.com',
+                  'title': '',
+                  'title_heading_type': 'h2'
                 },
-                'text': 'contact@business.com',
-                'title': '',
-                'title_heading_type': 'h2'
-              },
-              {
-                'image': {
-                  'alt': 'Address',
-                  'height': 230,
-                  'loading': 'disabled',
-                  'src': get_asset_url('../images/location.png'),
-                  'width': 230
-                },
-                'text': '2 Canal Park, Cambridge, MA 02141',
-                'title': '',
-                'title_heading_type': 'h2'
-              }
-            ]
+                {
+                  'image': {
+                    'alt': 'Address',
+                    'height': 230,
+                    'loading': 'disabled',
+                    'src': get_asset_url('../images/location.png'),
+                    'width': 230
+                  },
+                  'text': '2 Canal Park, Cambridge, MA 02141',
+                  'title': '',
+                  'title_heading_type': 'h2'
+                }
+              ]
+            }
           %}
           {% end_dnd_module %}
         {% end_dnd_row %}

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -10,7 +10,10 @@
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
   {# All templates are recommended to have an h1 present for both accessibility and SEO best practice. This should be at the top of the template before any other textual content. The h1 element below is within a dnd area to allow content editors the ability to adjust the content and alignment of the text. #}
-  {% dnd_area 'dnd_area' class='body-container body-container--home', label='Main section' %}
+  {% dnd_area 'dnd_area'
+    label='Main section',
+    class='body-container body-container--home'
+  %}
 
     {# Form section #}
     {% dnd_section
@@ -22,11 +25,14 @@
       },
       vertical_alignment='MIDDLE'
     %}
-      {% dnd_module path='@hubspot/linked_image',
-        img={
-          'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'size_type': 'auto',
-          'src': get_asset_url('../images/grayscale-mountain.png')
+      {% dnd_module
+        path='@hubspot/linked_image',
+        fields={
+          img: {
+            'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+            'size_type': 'auto',
+            'src': get_asset_url('../images/grayscale-mountain.png')
+          }
         },
         offset=0,
         width=6
@@ -56,7 +62,8 @@
     {% dnd_section
       vertical_alignment='MIDDLE'
     %}
-      {% dnd_module path='@hubspot/rich_text',
+      {% dnd_module
+        path='@hubspot/rich_text',
         offset=0,
         width=6
       %}
@@ -65,11 +72,14 @@
           <p>Use text and images to tell your company’s story. Explain what makes your product or service extraordinary.</p>
         {% end_module_attribute %}
       {% end_dnd_module %}
-      {% dnd_module path='@hubspot/linked_image',
-        img={
-          'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'size_type': 'auto',
-          'src': get_asset_url('../images/grayscale-mountain.png')
+      {% dnd_module
+        path='@hubspot/linked_image',
+        fields={
+          img: {
+            'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+            'size_type': 'auto',
+            'src': get_asset_url('../images/grayscale-mountain.png')
+          }
         },
         offset=6,
         width=6
@@ -88,18 +98,22 @@
       },
       vertical_alignment='MIDDLE'
     %}
-      {% dnd_module path='@hubspot/linked_image',
-        img={
-          'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'loading': 'lazy',
-          'size_type': 'auto',
-          'src': get_asset_url('../images/grayscale-mountain.png')
+      {% dnd_module
+        path='@hubspot/linked_image',
+        fields={
+          img: {
+            'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+            'loading': 'lazy',
+            'size_type': 'auto',
+            'src': get_asset_url('../images/grayscale-mountain.png')
+          }
         },
         offset=0,
         width=6
       %}
       {% end_dnd_module %}
-      {% dnd_module path='@hubspot/rich_text',
+      {% dnd_module
+        path='@hubspot/rich_text',
         offset=6,
         width=6
       %}
@@ -152,7 +166,8 @@
             }
           }
         %}
-          {% dnd_module path='@hubspot/rich_text',
+          {% dnd_module
+            path='@hubspot/rich_text',
             horizontal_alignment='CENTER'
           %}
             {% module_attribute 'html' %}
@@ -164,8 +179,11 @@
           {% end_dnd_module %}
         {% end_dnd_row %}
         {% dnd_row %}
-          {% dnd_module path='../modules/customizable-button',
-            button_text='See more options',
+          {% dnd_module
+            path='../modules/customizable-button',
+            fields={
+              button_text: 'See more options'
+            },
             horizontal_alignment='CENTER'
           %}
           {% end_dnd_module %}
@@ -189,12 +207,15 @@
         width=4
       %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/linked_image',
-            img={
-              'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-              'loading': 'lazy',
-              'size_type': 'auto',
-              'src': get_asset_url('../images/grayscale-mountain.png')
+          {% dnd_module
+            path='@hubspot/linked_image',
+            fields={
+              img: {
+                'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+                'loading': 'lazy',
+                'size_type': 'auto',
+                'src': get_asset_url('../images/grayscale-mountain.png')
+              }
             }
           %}
           {% end_dnd_module %}
@@ -213,12 +234,15 @@
         width=4
       %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/linked_image',
-            img={
-              'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-              'loading': 'lazy',
-              'size_type': 'auto',
-              'src': get_asset_url('../images/grayscale-mountain.png')
+          {% dnd_module
+            path='@hubspot/linked_image',
+            fields={
+              img: {
+                'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+                'loading': 'lazy',
+                'size_type': 'auto',
+                'src': get_asset_url('../images/grayscale-mountain.png')
+              }
             }
           %}
           {% end_dnd_module %}
@@ -237,12 +261,15 @@
         width=4
       %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/linked_image',
-            img={
-              'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-              'loading': 'lazy',
-              'size_type': 'auto',
-              'src': get_asset_url('../images/grayscale-mountain.png')
+          {% dnd_module
+            path='@hubspot/linked_image',
+            fields={
+              img: {
+                'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+                'loading': 'lazy',
+                'size_type': 'auto',
+                'src': get_asset_url('../images/grayscale-mountain.png')
+              }
             }
           %}
           {% end_dnd_module %}

--- a/src/templates/hubdb.html
+++ b/src/templates/hubdb.html
@@ -45,9 +45,12 @@
         {% if page_level == 0 and rows|length > 0 %}
           <header>
             <h1>
-              {% module "page_title" path="@hubspot/text"
-                label="Page title",
-                value="Root Page Title"
+              {% module 'page_title'
+                path='@hubspot/text'
+                label='Page title',
+                fields={
+                  value: 'Root Page Title'
+                }
               %}
             </h1>
           </header>

--- a/src/templates/landing-page.html
+++ b/src/templates/landing-page.html
@@ -13,7 +13,10 @@
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area' class='body-container body-container--landing-page', label='Main section' %}
+  {% dnd_area 'dnd_area'
+    label='Main section',
+    class='body-container body-container--landing-page'
+  %}
 
     {# Form section #}
     {% dnd_section
@@ -25,11 +28,14 @@
       },
       vertical_alignment='MIDDLE'
     %}
-      {% dnd_module path='@hubspot/linked_image',
-        img={
-          'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'size_type': 'auto',
-          'src': get_asset_url('../images/grayscale-mountain.png')
+      {% dnd_module
+        path='@hubspot/linked_image',
+        fields={
+          img: {
+            'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+            'size_type': 'auto',
+            'src': get_asset_url('../images/grayscale-mountain.png')
+          }
         },
         offset=0,
         width=6
@@ -64,12 +70,15 @@
         width=4
       %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/linked_image',
-            img={
-              'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-              'loading': 'lazy',
-              'size_type': 'auto',
-              'src': get_asset_url('../images/grayscale-mountain.png')
+          {% dnd_module
+            path='@hubspot/linked_image',
+            fields={
+              img: {
+                'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+                'loading': 'lazy',
+                'size_type': 'auto',
+                'src': get_asset_url('../images/grayscale-mountain.png')
+              }
             }
           %}
           {% end_dnd_module %}
@@ -88,12 +97,15 @@
         width=4
       %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/linked_image',
-            img={
-              'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-              'loading': 'lazy',
-              'size_type': 'auto',
-              'src': get_asset_url('../images/grayscale-mountain.png')
+          {% dnd_module
+            path='@hubspot/linked_image',
+            fields={
+              img: {
+                'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+                'loading': 'lazy',
+                'size_type': 'auto',
+                'src': get_asset_url('../images/grayscale-mountain.png')
+              }
             }
           %}
           {% end_dnd_module %}
@@ -112,12 +124,15 @@
         width=4
       %}
         {% dnd_row %}
-          {% dnd_module path='@hubspot/linked_image',
-            img={
-              'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-              'loading': 'lazy',
-              'size_type': 'auto',
-              'src': get_asset_url('../images/grayscale-mountain.png')
+          {% dnd_module
+            path='@hubspot/linked_image',
+            fields={
+              img: {
+                'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+                'loading': 'lazy',
+                'size_type': 'auto',
+                'src': get_asset_url('../images/grayscale-mountain.png')
+              }
             }
           %}
           {% end_dnd_module %}

--- a/src/templates/partials/footer.html
+++ b/src/templates/partials/footer.html
@@ -3,23 +3,27 @@
   label: Footer
 -->
 <footer class="footer">
-  {% dnd_area 'footer' class='footer__container content-wrapper', label='Footer' %}
+  {% dnd_area 'footer'
+    label='Footer',
+    class='footer__container content-wrapper'
+  %}
 
     {# Social follow and copyright section #}
     {% dnd_section %}
       {% dnd_column %}
         {% dnd_row %}
-          {% dnd_module path='../../modules/social-follow',
+          {% dnd_module
+            path='../../modules/social-follow',
             label='Social follow'
-          %}
-            {% module_attribute 'social_link' is_json=True %}
-              [
-                {"social_account": "facebook-f"},
-                {"social_account": "linkedin-in"},
-                {"social_account": "twitter"},
-                {"social_account": "instagram"}
+            fields={
+              social_link: [
+                { 'social_account': 'facebook-f' },
+                { 'social_account': 'linkedin-in' },
+                { 'social_account': 'twitter' },
+                { 'social_account': 'instagram' }
               ]
-            {% end_module_attribute %}
+            }
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
         {% dnd_row

--- a/src/templates/partials/header-no-navigation.html
+++ b/src/templates/partials/header-no-navigation.html
@@ -5,7 +5,10 @@
 <header class="header header--no-navigation">
 
   {# Top header drag and drop area #}
-  {% dnd_area 'header-top' label='Top header' class='content-wrapper' %}
+  {% dnd_area 'header_top'
+    label='Top header',
+    class='content-wrapper'
+  %}
   {% end_dnd_area %}
   {# End top header drag and drop area #}
 
@@ -20,7 +23,10 @@
   </div>
 
   {# Bottom header drag and drop area #}
-  {% dnd_area 'header-bottom' label='Bottom header' class='content-wrapper' %}
+  {% dnd_area 'header_bottom'
+    label='Bottom header',
+    class='content-wrapper'
+  %}
   {% end_dnd_area %}
   {# End bottom header drag and drop area #}
 

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -8,7 +8,10 @@
   <a href="#main-content" class="header__skip">Skip to content</a>
 
   {# Top header drag and drop area #}
-  {% dnd_area 'header-top' label='Top header' class='content-wrapper' %}
+  {% dnd_area 'header_top'
+    label='Top header',
+    class='content-wrapper'
+  %}
   {% end_dnd_area %}
   {# End top header drag and drop area #}
 
@@ -28,19 +31,25 @@
         {% if content.translated_content|length || is_listing_view && group.translations %}
           <div class="header__language-switcher header--element">
             <div class="header__language-switcher--label">
-              {% module 'language-switcher' path='@hubspot/language_switcher',
+              {% module 'language-switcher'
+                path='@hubspot/language_switcher',
                 label='Language switcher',
-                display_mode='localized'
+                fields={
+                  display_mode: 'localized'
+                }
               %}
               <div class="header__language-switcher--label-current"> {{ locale_name(locale) }}</div>
             </div>
           </div>
         {% endif %}
         <div class="header__search header--element">
-          {% module 'site_search' path='@hubspot/search_input',
+          {% module 'site_search'
+            path='@hubspot/search_input',
             label='Search',
-            field_label='Search',
-            placeholder=''
+            fields={
+              field_label: 'Search',
+              placeholder: ''
+            }
           %}
         </div>
       </div>
@@ -55,7 +64,8 @@
         <div class="header--toggle header__search--toggle"></div>
         <div class="header__close--toggle"></div>
         <div class="header__navigation header--element">
-          {% module 'navigation-primary' path='../../modules/menu-section',
+          {% module 'navigation-primary'
+            path='../../modules/menu-section',
             label='Primary navigation'
           %}
         </div>
@@ -68,7 +78,10 @@
   </div>
 
   {# Bottom header drag and drop area #}
-  {% dnd_area 'header-bottom' label='Bottom header' class='content-wrapper' %}
+  {% dnd_area 'header_bottom'
+    label='Bottom header',
+    class='content-wrapper'
+  %}
   {% end_dnd_area %}
   {# End bottom header drag and drop area #}
 

--- a/src/templates/pricing.html
+++ b/src/templates/pricing.html
@@ -9,11 +9,15 @@
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area' class='body-container body-container--pricing', label='Main section' %}
+  {% dnd_area 'dnd_area'
+    label='Main section'
+    class='body-container body-container--pricing'
+  %}
 
     {# Heading section #}
     {% dnd_section %}
-      {% dnd_module path='@hubspot/rich_text',
+      {% dnd_module
+        path='@hubspot/rich_text',
         label='Title',
         horizontal_alignment='CENTER'
       %}
@@ -30,69 +34,78 @@
         'top': 0
       }
     %}
-      {% dnd_module path='../modules/pricing-card',
-        button_text='Buy starter',
-        description='For individuals or team just getting started with sales.',
-        features=[
-          'Ad management',
-          'Live chat',
-          'Conversational bots',
-          'Forms',
-          'Pop-up forms',
-          'Contact website activity',
-          'List segmentation',
-          'Email marketing',
-          'Ad retargeting'
-        ],
+      {% dnd_module
+        path='../modules/pricing-card',
+        fields={
+          button_text: 'Buy starter',
+          description: 'For individuals or team just getting started with sales.',
+          features:[
+            'Ad management',
+            'Live chat',
+            'Conversational bots',
+            'Forms',
+            'Pop-up forms',
+            'Contact website activity',
+            'List segmentation',
+            'Email marketing',
+            'Ad retargeting'
+          ],
+          price: '$0',
+          tier: 'Starter',
+          tier_heading_type: 'h2',
+          timeframe: '/mo'
+        },
         offset=0,
-        price='$0',
-        tier='Starter',
-        tier_heading_type='h2',
-        timeframe='/mo',
         width=4
       %}
       {% end_dnd_module %}
-      {% dnd_module path='../modules/pricing-card',
-        button_text='Buy professional',
-        description='For teams that need to create sales plans with confidence.',
-        features=[
-          'Marketing automation',
-          'Smart content',
-          'Content creation tools',
-          'SEO & content strategy',
-          'Social media',
-          'A/B testing',
-          'Landing pages',
-          'Calls-to-action',
-          'Video hosting'
-        ],
+      {% dnd_module
+        path='../modules/pricing-card',
+        fields={
+          button_text: 'Buy professional',
+          description: 'For teams that need to create sales plans with confidence.',
+          features:[
+            'Marketing automation',
+            'Smart content',
+            'Content creation tools',
+            'SEO & content strategy',
+            'Social media',
+            'A/B testing',
+            'Landing pages',
+            'Calls-to-action',
+            'Video hosting'
+          ],
+          price: '$1200',
+          tier: 'Professional',
+          tier_heading_type: 'h2',
+          timeframe: '/mo'
+        },
         offset=4,
-        price='$1200',
-        tier='Professional',
-        tier_heading_type='h2',
-        timeframe='/mo',
         width=4
       %}
       {% end_dnd_module %}
-      {% dnd_module path='../modules/pricing-card',
-        button_text='Buy enterprise',
-        description='For teams that need additional security, control, and support.',
-        features=[
-          'Content partitioning',
-          'Hierarchical teams',
-          'Single sign-on',
-          'Social permissions',
-          'Additional domains',
-          'Email send frequency cap',
-          'Calculated properties',
-          'CMS membership',
-          'Filtered analytics view'
-        ],
+      {% dnd_module
+        path='../modules/pricing-card',
+        fields={
+          button_text: 'Buy enterprise',
+          description: 'For teams that need additional security, control, and support.',
+          features:[
+            'Content partitioning',
+            'Hierarchical teams',
+            'Single sign-on',
+            'Social permissions',
+            'Additional domains',
+            'Email send frequency cap',
+            'Calculated properties',
+            'CMS membership',
+            'Filtered analytics view'
+          ],
+          price: '$3200',
+          tier: 'Enterprise',
+          tier_heading_type: 'h2',
+          timeframe: '/mo'
+        },
         offset=8,
-        price='$3200',
-        tier='Enterprise',
-        tier_heading_type='h2',
-        timeframe='/mo',
         width=4
       %}
       {% end_dnd_module %}

--- a/src/templates/qa-test.html
+++ b/src/templates/qa-test.html
@@ -8,7 +8,10 @@
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
 <main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area' class='body-container body-container--qa-test', label='Main section' %}
+  {% dnd_area 'dnd_area'
+    label='Main section',
+    class='body-container body-container--qa-test'
+  %}
 
     {# Typography section #}
     {% dnd_section %}

--- a/src/templates/system/404.html
+++ b/src/templates/system/404.html
@@ -15,11 +15,24 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="error-page" data-error="404">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Page not found.</h1>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
-      {% module 'button' path='../../modules/customizable-button' button_text='Go Home' link={ 'url': { 'type': 'EXTERNAL', 'href': '/'}, 'open_in_new_tab': false, 'no_follow': false } %}
+        {% module_attribute 'html' %}
+          <h1>Page not found.</h1>
+        {% end_module_attribute %}
+      {% end_module_block %}
+      {% module 'button'
+        path='../../modules/customizable-button',
+        fields={
+          button_text: 'Go Home',
+          link: {
+            'url': { 'type': 'EXTERNAL', 'href': '/'},
+            'open_in_new_tab': false,
+            'no_follow': false
+          }
+        }
+      %}
     </div>
   </section>
 </main>

--- a/src/templates/system/500.html
+++ b/src/templates/system/500.html
@@ -15,10 +15,14 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="error-page" data-error="500">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Something isn\'t quite right</h1><p>Sorry, an internal server error occurred. But have no fear, we\'re on the case!</p>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
+        {% module_attribute 'html' %}
+          <h1>Something isn't quite right</h1>
+          <p>Sorry, an internal server error occurred. But have no fear, we're on the case!</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
     </div>
   </section>
 </main>

--- a/src/templates/system/backup-unsubscribe.html
+++ b/src/templates/system/backup-unsubscribe.html
@@ -16,8 +16,8 @@
   <section class="content-wrapper">
     <div class="systems-page">
       {% module 'backup_unsubscribe'
-        extra_classes='backup-unsubscribe',
-        path='@hubspot/email_simple_subscription'
+        path='@hubspot/email_simple_subscription',
+        extra_classes='backup-unsubscribe'
       %}
     </div>
   </section>

--- a/src/templates/system/membership-login.html
+++ b/src/templates/system/membership-login.html
@@ -18,10 +18,14 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h2>Sign in to view this page</h2><p>This page is only available to people who have been given access.</p>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
+        {% module_attribute 'html' %}
+          <h2>Sign in to view this page</h2>
+          <p>This page is only available to people who have been given access.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
       <div class="form-container">
         {% member_login 'my_login'
           email_label= 'Email',
@@ -33,8 +37,8 @@
       </div>
       <div>
         {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
+          path='@hubspot/rich_text',
+          label='Contact admin'
         %}
           {% module_attribute 'html' %}
             <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>

--- a/src/templates/system/membership-register.html
+++ b/src/templates/system/membership-register.html
@@ -18,10 +18,14 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h4>Welcome!</h4><p>Set up your password to sign in and see the content you now have access to.</p>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
+        {% module_attribute 'html' %}
+          <h4>Welcome!</h4>
+          <p>Set up your password to sign in and see the content you now have access to.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
       <div class="form-container">
         {% member_register 'my_register'
           email_label='Email',
@@ -32,8 +36,8 @@
       </div>
       <div>
         {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
+          path='@hubspot/rich_text',
+          label='Contact admin'
         %}
           {% module_attribute 'html' %}
             <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>

--- a/src/templates/system/membership-reset-password-request.html
+++ b/src/templates/system/membership-reset-password-request.html
@@ -18,10 +18,14 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h4>Reset your password</h4><p>What email address should we send a password reset email to?</p>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
+        {% module_attribute 'html' %}
+          <h4>Reset your password</h4>
+          <p>What email address should we send a password reset email to?</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
       <div class="form-container">
         {% password_reset_request 'my_password_reset_request'
           email_label='Email',
@@ -30,8 +34,8 @@
       </div>
       <div>
         {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
+          path='@hubspot/rich_text',
+          label='Contact admin'
         %}
           {% module_attribute 'html' %}
             <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>

--- a/src/templates/system/membership-reset-password.html
+++ b/src/templates/system/membership-reset-password.html
@@ -18,10 +18,14 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h4>Reset your password</h4><p>Enter a new password.</p>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
+        {% module_attribute 'html' %}
+          <h4>Reset your password</h4>
+          <p>Enter a new password.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
       <div class="form-container">
         {% password_reset 'my_password_reset'
           password_confirm_label='Confirm Password',
@@ -31,8 +35,8 @@
       </div>
       <div>
         {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
+          path='@hubspot/rich_text',
+          label='Contact admin'
         %}
           {% module_attribute 'html' %}
             <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>

--- a/src/templates/system/password-prompt.html
+++ b/src/templates/system/password-prompt.html
@@ -15,13 +15,17 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Password Required</h1><p>Please enter the password required to view this page.</p>'
+      {% module_block module 'content'
+        path='@hubspot/rich_text'
       %}
+        {% module_attribute 'html' %}
+          <h1>Password Required</h1>
+          <p>Please enter the password required to view this page.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
       {% module 'password_prompt'
-        extra_classes='password-prompt',
-        path='@hubspot/password_prompt'
+        path='@hubspot/password_prompt',
+        extra_classes='password-prompt'
       %}
     </div>
   </section>

--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -16,16 +16,14 @@
   <section class="content-wrapper">
     <div class="systems-page systems-page--search-results">
       {% module_block module 'search_results_content'
-        label='Search results heading',
-        path='@hubspot/rich_text'
+        path='@hubspot/rich_text',
+        label='Search results heading'
       %}
         {% module_attribute 'html' %}
           <h1>Results for "{{ request.query_dict.term|escape }}"</h1>
         {% end_module_attribute %}
       {% end_module_block %}
-      {% module 'search_results'
-        path='@hubspot/search_results'
-      %}
+      {% module 'search_results' path='@hubspot/search_results' %}
     </div>
   </section>
 </main>

--- a/src/templates/system/subscription-preferences.html
+++ b/src/templates/system/subscription-preferences.html
@@ -15,9 +15,7 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'subscription_preferences'
-        path='@hubspot/email_subscriptions'
-      %}
+      {% module 'subscription_preferences' path='@hubspot/email_subscriptions' %}
     </div>
   </section>
 </main>

--- a/src/templates/system/subscriptions-confirmation.html
+++ b/src/templates/system/subscriptions-confirmation.html
@@ -15,9 +15,7 @@
 <main id="main-content" class="body-container-wrapper">
   <section class="content-wrapper">
     <div class="systems-page">
-      {% module 'subscriptions_confirmation'
-        path='@hubspot/email_subscriptions_confirmation'
-      %}
+      {% module 'subscriptions_confirmation' path='@hubspot/email_subscriptions_confirmation' %}
     </div>
   </section>
 </main>


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

- Placed module based fields within the new `fields={}` parameter ([documented here](https://developers.hubspot.com/docs/cms/building-blocks/modules/using-modules-in-templates#passing-fields-that-have-dnd-associated-parameters)). This helps visually separate module based fields and built in fields ([e.g. `width`, `offset`](https://developers.hubspot.com/docs/cms/hubl/tags/dnd-areas#drag-and-drop-module-code-dnd-module-code-)). 
- Updated any existing modules code/dnd_area code to follow along with the style guide. 

**Relevant links**

Resolves #329 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech @ajlaporte 
