### PR TITLE
Adjust card section module to account for responsive sizing options

### DIFF
--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -13,7 +13,7 @@
         "label": "Image",
         "name": "image",
         "type": "image",
-        "responsive": false,
+        "responsive": true,
         "resizable": true,
         "show_loading" : true,
         "default": {

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -1,9 +1,15 @@
 <div class="cards">
   {% for card in module.card %}
-    {% set loadingAttr = card.image.loading != 'disabled' ? 'loading="{{ card.image.loading }}"' : '' %}
     <section class="cards__card card">
       {% if card.image.src %}
-        <img class="card__image" src="{{ card.image.src }}" alt="{{ card.image.alt }}" width="{{ card.image.width }}" height="{{ card.image.height }}" {{ loadingAttr }}>
+        {% set sizeAttrs = 'width="{{ card.image.width }}" height="{{ card.image.height }}"' %}
+        {% if card.image.size_type == 'auto' %}
+          {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+        {% elif card.image.size_type == 'auto_custom_max' %}
+          {% set sizeAttrs = 'width="{{ card.image.max_width }}" height="{{ card.image.max_height }}" style="max-width: 100%; max-height: auto;"' %}
+        {% endif %}
+         {% set loadingAttr = card.image.loading != 'disabled' ? 'loading="{{ card.image.loading }}"' : '' %}
+        <img class="card__image" src="{{ card.image.src }}" alt="{{ card.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
       {% endif %}
       <div class="card__text">
         {% if card.title %}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Turning on responsive options for the images in the card section. There were no particular reasons this was turned off to begin with so it seems to make sense to turn them on. This also adds in the HTML/HubL to support those responsive options. 

**Relevant links**

Resolves #336 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
