### PR TITLE
Inlining label with search field in header

### DIFF
--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -149,6 +149,22 @@
   display: none;
 }
 
+@media (min-width: 767px) {
+  .header__search form {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+  }
+
+  .header__search label {
+    margin: 0 20px 0 0;
+  }
+
+  .header__search .hs-search-field__input {
+    width: auto;
+  }
+}
+
 @media (max-width: 767px) {
   .header__search {
     border-top: 2px solid #CED4DB;


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Puts the search field label inline with the search field as opposed to stacking them. I did keep them stacked on mobile because keeping them side by side didn't leave for much room in the field itself. 

**Relevant links**

[Example page](https://jrosa-102019231.hs-sitesqa.com/-temporary-slug-a078d5b3-b56d-43ce-b88b-ba81f1259fb3?hs_preview=XaqFcwCk-4516126583)
Resolves #302 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
