### PR TITLE
Adding custom max sizes for images

### DIFF
--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -18,7 +18,9 @@
       {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Coworkers sitting together and smiling outside.',
-          'size_type': 'auto',
+          'max_height': 449,
+          'max_width': 605,
+          'size_type': 'auto_custom_max',
           'src': get_asset_url('../images/team-image.png')
         },
         offset=0,

--- a/src/templates/contact.html
+++ b/src/templates/contact.html
@@ -31,10 +31,11 @@
               {
                 'image': {
                   'alt': 'Phone number',
-                  'height': 230,
                   'loading': 'disabled',
-                  'src': get_asset_url('../images/phone.png'),
-                  'width': 230
+                  'max_height': 230,
+                  'max_width': 230,
+                  'size_type': 'auto_custom_max',
+                  'src': get_asset_url('../images/phone.png')
                 },
                 'text': '(887) 929-0687',
                 'title': '',
@@ -43,10 +44,11 @@
               {
                 'image': {
                   'alt': 'Email',
-                  'height': 230,
                   'loading': 'disabled',
-                  'src': get_asset_url('../images/email.png'),
-                  'width': 230
+                  'max_height': 230,
+                  'max_width': 230,
+                  'size_type': 'auto_custom_max',
+                  'src': get_asset_url('../images/email.png')
                 },
                 'text': 'contact@business.com',
                 'title': '',
@@ -55,10 +57,11 @@
               {
                 'image': {
                   'alt': 'Address',
-                  'height': 230,
                   'loading': 'disabled',
-                  'src': get_asset_url('../images/location.png'),
-                  'width': 230
+                  'max_height': 230,
+                  'max_width': 230,
+                  'size_type': 'auto_custom_max',
+                  'src': get_asset_url('../images/location.png')
                 },
                 'text': '2 Canal Park, Cambridge, MA 02141',
                 'title': '',

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -25,7 +25,10 @@
       {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'size_type': 'auto',
+          'loading': 'disabled',
+          'max_height': 451,
+          'max_width': 605,
+          'size_type': 'auto_custom_max',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },
         offset=0,
@@ -68,7 +71,10 @@
       {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'size_type': 'auto',
+          'loading': 'disabled',
+          'max_height': 451,
+          'max_width': 605,
+          'size_type': 'auto_custom_max',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },
         offset=6,
@@ -92,7 +98,9 @@
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
           'loading': 'lazy',
-          'size_type': 'auto',
+          'max_height': 451,
+          'max_width': 605,
+          'size_type': 'auto_custom_max',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },
         offset=0,
@@ -193,7 +201,9 @@
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
               'loading': 'lazy',
-              'size_type': 'auto',
+              'max_height': 451,
+              'max_width': 605,
+              'size_type': 'auto_custom_max',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
           %}
@@ -217,7 +227,9 @@
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
               'loading': 'lazy',
-              'size_type': 'auto',
+              'max_height': 451,
+              'max_width': 605,
+              'size_type': 'auto_custom_max',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
           %}
@@ -241,7 +253,9 @@
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
               'loading': 'lazy',
-              'size_type': 'auto',
+              'max_height': 451,
+              'max_width': 605,
+              'size_type': 'auto_custom_max',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
           %}

--- a/src/templates/landing-page.html
+++ b/src/templates/landing-page.html
@@ -28,7 +28,10 @@
       {% dnd_module path='@hubspot/linked_image',
         img={
           'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'size_type': 'auto',
+          'loading': 'disabled',
+          'max_height': 451,
+          'max_width': 605,
+          'size_type': 'auto_custom_max',
           'src': get_asset_url('../images/grayscale-mountain.png')
         },
         offset=0,
@@ -68,7 +71,9 @@
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
               'loading': 'lazy',
-              'size_type': 'auto',
+              'max_height': 451,
+              'max_width': 605,
+              'size_type': 'auto_custom_max',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
           %}
@@ -92,7 +97,9 @@
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
               'loading': 'lazy',
-              'size_type': 'auto',
+              'max_height': 451,
+              'max_width': 605,
+              'size_type': 'auto_custom_max',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
           %}
@@ -116,7 +123,9 @@
             img={
               'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
               'loading': 'lazy',
-              'size_type': 'auto',
+              'max_height': 451,
+              'max_width': 605,
+              'size_type': 'auto_custom_max',
               'src': get_asset_url('../images/grayscale-mountain.png')
             }
           %}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adding custom max sizes to image modules within the template of the theme. This change will add the images max width/max height as the height/width attribute in the HTML which will help with reducing cumulative layout shift and help trigger automatic image resizing within HubSpot while keeping the image responsive. 

**Relevant links**

Fixes #336 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @jmclaren and @ajlaporte
