### PR TITLE
Adding max-widths on images  applicable images

### DIFF
--- a/src/css/components/_default-modules.css
+++ b/src/css/components/_default-modules.css
@@ -75,3 +75,12 @@
     top: auto;
   }
 }
+
+/* CTA, logo, and rich text images */
+
+.hs_cos_wrapper_type_cta img,
+.hs_cos_wrapper_type_logo img,
+.hs_cos_wrapper_type_rich_text img {
+  height: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds a max-width of 100% on certain modules that include images (e.g. logo, CTA, and rich text). The default image module has built in options for responsiveness already and I wanted to make sure this wouldn't mess with custom modules so I chose to not use the `:not` pseudo selector. 

**Relevant links**

Fixes https://github.com/HubSpot/cms-theme-boilerplate/issues/149 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
