### PR TITLE
Fixing wrap on menu items

### DIFF
--- a/src/modules/menu-section.module/module.css
+++ b/src/modules/menu-section.module/module.css
@@ -42,7 +42,6 @@
 
 .submenu.level-1 {
   display: inline-block;
-  white-space: nowrap;
 }
 
 .submenu.level-1 > li {


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Fixes issue with menu items not wrapping in child menus. There was a `white-space: nowrap;` that was set on `.submenu.level-1` which the child menus are contained in. After testing around I think it makes sense to remove this entirely vs. add `white-space: normal` to non level 1 submenus because forcing that on the top level menu items could break the site's responsiveness. 

**Relevant links**

Fixes #352 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
