### PR TITLE
Fixing submenu z-index

### DIFF
--- a/src/modules/menu-section.module/module.css
+++ b/src/modules/menu-section.module/module.css
@@ -68,6 +68,10 @@
   width: 0;
 }
 
+.submenu {
+  z-index: 2;
+}
+
 .submenu.level-2 {
   border: 2px solid #D1D6DC;
   border-radius: 6px;
@@ -103,7 +107,7 @@
   transform: rotate(45deg);
   transition: background-color 0.3s;
   width: 30px;
-  z-index: 1;
+  z-index: 2;
 }
 
 .submenu.level-2 > li:first-child:hover:before,
@@ -293,7 +297,6 @@
     transform: unset;
     visibility: visible;
     width: 100%;
-    z-index: 2;
   }
 
   .submenu.level-2 .menu-item {


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

The submenu's z-index was a 1 on desktop therefore if a different item below it also had a z-index of 1 the submenu would flow behind it. To resolve this, I added `submenu { z-index: 2; }` per the suggestion of @DreamDevourer

**Relevant links**

Resolves #354 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.
