### PR TITLE
Add style fields to theme modules

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -83,7 +83,7 @@
   function toggleDisabled() {
     var emailSubItem = document.querySelectorAll('#email-prefs-form .item');
 
-    emailSubItem.forEach(function(item){
+    emailSubItem.forEach(function (item) {
       var emailSubItemInput = item.querySelector('input');
 
       if (emailGlobalUnsub.checked) {
@@ -102,7 +102,6 @@
     if (!document.body) {
       return;
     } else {
-
       // Function dependent on language switcher
       if (langSwitcher) {
         langToggle.addEventListener('click', toggleLang);
@@ -127,8 +126,6 @@
       if (emailGlobalUnsub) {
         emailGlobalUnsub.addEventListener('change', toggleDisabled);
       }
-
     }
   });
-
 })();

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -239,12 +239,7 @@
               {
                 "label": "Border",
                 "name": "border",
-                "type": "border",
-                "visibility": {
-                  "hidden_subfields": {
-                    "border_radius": true
-                  }
-                }
+                "type": "border"
               }
             ]
           },

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -32,30 +32,12 @@
         "name": "title_heading_type",
         "type": "choice",
         "choices": [
-          [
-            "h1",
-            "Heading 1"
-          ],
-          [
-            "h2",
-            "Heading 2"
-          ],
-          [
-            "h3",
-            "Heading 3"
-          ],
-          [
-            "h4",
-            "Heading 4"
-          ],
-          [
-            "h5",
-            "Heading 5"
-          ],
-          [
-            "h6",
-            "Heading 6"
-          ]
+          ["h1", "Heading 1"],
+          ["h2", "Heading 2"],
+          ["h3", "Heading 3"],
+          ["h4", "Heading 4"],
+          ["h5", "Heading 5"],
+          ["h6", "Heading 6"]
         ],
         "display": "select",
         "required": true,
@@ -135,22 +117,10 @@
             "display": "radio",
             "type": "choice",
             "choices": [
-              [
-                "none",
-                "None"
-              ],
-              [
-                "bg_color",
-                "Background color"
-              ],
-              [
-                "bg_gradient",
-                "Background gradient"
-              ],
-              [
-                "bg_image",
-                "Background image"
-              ]
+              ["none", "None"],
+              ["bg_color", "Background color"],
+              ["bg_gradient", "Background gradient"],
+              ["bg_image", "Background image"]
             ],
             "default": "none"
           },

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -15,9 +15,9 @@
         "type": "image",
         "responsive": true,
         "resizable": true,
-        "show_loading" : true,
+        "show_loading": true,
         "default": {
-          "loading" : "lazy"
+          "loading": "lazy"
         }
       },
       {
@@ -31,9 +31,34 @@
         "label": "Title heading type",
         "name": "title_heading_type",
         "type": "choice",
-        "choices": [["h1", "Heading 1"], ["h2", "Heading 2"], ["h3", "Heading 3"], ["h4", "Heading 4"], ["h5", "Heading 5"], ["h6", "Heading 6"]],
+        "choices": [
+          [
+            "h1",
+            "Heading 1"
+          ],
+          [
+            "h2",
+            "Heading 2"
+          ],
+          [
+            "h3",
+            "Heading 3"
+          ],
+          [
+            "h4",
+            "Heading 4"
+          ],
+          [
+            "h5",
+            "Heading 5"
+          ],
+          [
+            "h6",
+            "Heading 6"
+          ]
+        ],
         "display": "select",
-        "required" : true,
+        "required": true,
         "visibility": {
           "controlling_field": "card.title",
           "controlling_value_regex": "",
@@ -51,7 +76,7 @@
     "default": [
       {
         "image": {
-          "loading" : "lazy"
+          "loading": "lazy"
         },
         "title": "This is a title",
         "title_heading_type": "h3",
@@ -59,7 +84,7 @@
       },
       {
         "image": {
-          "loading" : "lazy"
+          "loading": "lazy"
         },
         "title": "This is a title",
         "title_heading_type": "h3",
@@ -67,7 +92,7 @@
       },
       {
         "image": {
-          "loading" : "lazy"
+          "loading": "lazy"
         },
         "title": "This is a title",
         "title_heading_type": "h3",
@@ -109,11 +134,23 @@
             "name": "bg_type",
             "display": "radio",
             "type": "choice",
-            "choices":[
-              ["none", "None"],
-              ["bg_color", "Background color"],
-              ["bg_gradient", "Background gradient"],
-              ["bg_image", "Background image"]
+            "choices": [
+              [
+                "none",
+                "None"
+              ],
+              [
+                "bg_color",
+                "Background color"
+              ],
+              [
+                "bg_gradient",
+                "Background gradient"
+              ],
+              [
+                "bg_image",
+                "Background image"
+              ]
             ],
             "default": "none"
           },
@@ -149,11 +186,10 @@
           }
         ]
       },
-{
-            "label": "Border",
-            "name": "border",
-            "type": "border"
-
+      {
+        "label": "Border",
+        "name": "border",
+        "type": "border"
       },
       {
         "label": "Typgraphy",

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -89,7 +89,8 @@
           {
             "label": "Alignment",
             "name": "alignment",
-            "type": "alignment"
+            "type": "alignment",
+            "alignment_direction": "HORIZONTAL"
           },
           {
             "label": "Spacing",
@@ -139,7 +140,7 @@
           {
             "label": "Background image",
             "name": "bg_image",
-            "type": "image",
+            "type": "backgroundimage",
             "visibility": {
               "controlling_field": "style.background.bg_type",
               "controlling_value_regex": "bg_image",
@@ -148,17 +149,11 @@
           }
         ]
       },
-      {
-        "label": "Border",
-        "name": "border",
-        "type": "group",
-        "children": [
-          {
+{
             "label": "Border",
             "name": "border",
             "type": "border"
-          }
-        ]
+
       },
       {
         "label": "Typgraphy",

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -49,7 +49,7 @@
         "default": "h3"
       },
       {
-        "label": "Text",
+        "label": "Content",
         "name": "text",
         "type": "text",
         "default": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
@@ -83,93 +83,198 @@
     ]
   },
   {
-    "label": "Style",
-    "name": "style",
+    "label": "Styles",
+    "name": "styles",
     "type": "group",
     "tab": "STYLE",
     "children": [
       {
-        "label": "Alignment and spacing",
-        "name": "alignment_spacing",
-        "type": "Group",
+        "label": "Image",
+        "name": "image",
+        "type": "group",
         "children": [
+          {
+            "label": "Corner",
+            "name": "corner",
+            "type": "group",
+            "children": [
+              {
+                "label": "Radius",
+                "name": "radius",
+                "type": "number",
+                "display": "text",
+                "max": 100,
+                "step": 1,
+                "suffix": "px"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Title",
+        "name": "title",
+        "type": "group",
+        "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
           {
             "label": "Alignment",
             "name": "alignment",
-            "type": "alignment",
-            "alignment_direction": "HORIZONTAL"
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Content",
+        "name": "content",
+        "type": "group",
+        "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Card",
+        "name": "card",
+        "type": "group",
+        "children": [
+          {
+            "label": "Background",
+            "name": "background",
+            "type": "group",
+            "children": [
+              {
+                "label": "Background type",
+                "name": "background_type",
+                "id": "styles.card.background.background_type",
+                "type": "choice",
+                "choices": [
+                  ["none", "None"],
+                  ["color", "Color"],
+                  ["gradient", "Gradient"],
+                  ["image", "Image"]
+                ],
+                "display": "radio",
+                "default": "none"
+              },
+              {
+                "label": "Color",
+                "name": "color",
+                "type": "color",
+                "visibility": {
+                  "controlling_field": "styles.card.background.background_type",
+                  "controlling_value_regex": "color",
+                  "operator": "EQUAL"
+                }
+              },
+              {
+                "label": "Gradient",
+                "name": "gradient",
+                "type": "gradient",
+                "visibility": {
+                  "controlling_field": "styles.card.background.background_type",
+                  "controlling_value_regex": "gradient",
+                  "operator": "EQUAL"
+                }
+              },
+              {
+                "label": "Image",
+                "name": "image",
+                "type": "backgroundimage",
+                "visibility": {
+                  "controlling_field": "styles.card.background.background_type",
+                  "controlling_value_regex": "image",
+                  "operator": "EQUAL"
+                }
+              }
+            ]
+          },
+          {
+            "label": "Border",
+            "name": "border",
+            "type": "group",
+            "children": [
+              {
+                "label": "Border",
+                "name": "border",
+                "type": "border",
+                "visibility": {
+                  "hidden_subfields": {
+                    "border_radius": true
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "label": "Corner",
+            "name": "corner",
+            "type": "group",
+            "children": [
+              {
+                "label": "Radius",
+                "name": "radius",
+                "type": "number",
+                "display": "text",
+                "max": 100,
+                "step": 1,
+                "suffix": "px"
+              }
+            ]
           },
           {
             "label": "Spacing",
             "name": "spacing",
-            "type": "spacing"
-          }
-        ]
-      },
-      {
-        "label": "Background",
-        "name": "background",
-        "type": "group",
-        "children": [
-          {
-            "label": "Background type",
-            "name": "bg_type",
-            "display": "radio",
-            "type": "choice",
-            "choices": [
-              ["none", "None"],
-              ["bg_color", "Background color"],
-              ["bg_gradient", "Background gradient"],
-              ["bg_image", "Background image"]
-            ],
-            "default": "none"
-          },
-          {
-            "label": "Background color",
-            "name": "bg_color",
-            "type": "color",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_color",
-              "operator": "EQUAL"
-            }
-          },
-          {
-            "label": "Background gradient",
-            "name": "bg_gradient",
-            "type": "gradient",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_gradient",
-              "operator": "EQUAL"
-            }
-          },
-          {
-            "label": "Background image",
-            "name": "bg_image",
-            "type": "backgroundimage",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_image",
-              "operator": "EQUAL"
-            }
-          }
-        ]
-      },
-      {
-        "label": "Border",
-        "name": "border",
-        "type": "border"
-      },
-      {
-        "label": "Typgraphy",
-        "name": "typography",
-        "type": "group",
-        "children": [
-          {
-            "label": "Font",
-            "name": "font",
-            "type": "font"
+            "type": "group",
+            "children": [
+              {
+                "label": "Spacing",
+                "name": "spacing",
+                "type": "spacing"
+              }
+            ]
           }
         ]
       }

--- a/src/modules/card-section.module/fields.json
+++ b/src/modules/card-section.module/fields.json
@@ -74,5 +74,104 @@
         "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
       }
     ]
+  },
+  {
+    "label": "Style",
+    "name": "style",
+    "type": "group",
+    "tab": "STYLE",
+    "children": [
+      {
+        "label": "Alignment and spacing",
+        "name": "alignment_spacing",
+        "type": "Group",
+        "children": [
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "alignment"
+          },
+          {
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "spacing"
+          }
+        ]
+      },
+      {
+        "label": "Background",
+        "name": "background",
+        "type": "group",
+        "children": [
+          {
+            "label": "Background type",
+            "name": "bg_type",
+            "display": "radio",
+            "type": "choice",
+            "choices":[
+              ["none", "None"],
+              ["bg_color", "Background color"],
+              ["bg_gradient", "Background gradient"],
+              ["bg_image", "Background image"]
+            ],
+            "default": "none"
+          },
+          {
+            "label": "Background color",
+            "name": "bg_color",
+            "type": "color",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_color",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background gradient",
+            "name": "bg_gradient",
+            "type": "gradient",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_gradient",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background image",
+            "name": "bg_image",
+            "type": "image",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_image",
+              "operator": "EQUAL"
+            }
+          }
+        ]
+      },
+      {
+        "label": "Border",
+        "name": "border",
+        "type": "group",
+        "children": [
+          {
+            "label": "Border",
+            "name": "border",
+            "type": "border"
+          }
+        ]
+      },
+      {
+        "label": "Typgraphy",
+        "name": "typography",
+        "type": "group",
+        "children": [
+          {
+            "label": "Font",
+            "name": "font",
+            "type": "font"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/src/modules/card-section.module/meta.json
+++ b/src/modules/card-section.module/meta.json
@@ -1,5 +1,5 @@
 {
-  "label": "Card section",
+  "label": "Card",
   "css_assets": [],
   "external_js": [],
   "global": false,

--- a/src/modules/card-section.module/module.css
+++ b/src/modules/card-section.module/module.css
@@ -13,22 +13,11 @@
   max-width: 100%;
   width: 250px;
 }
-.cards--center {
-  text-align: center;
-}
-.cards--right {
-  text-align: right;
-}
+
 .card__image {
   height: auto;
   max-width: 100%;
   padding: 0.7rem 10px;
-}
-.cards--center .card__image {
-  margin: 0 auto;
-}
-.cards--right .card__image {
- margin: 0 0 0 auto;
 }
 
 .card__text {

--- a/src/modules/card-section.module/module.css
+++ b/src/modules/card-section.module/module.css
@@ -13,16 +13,25 @@
   max-width: 100%;
   width: 250px;
 }
-
+.cards--center {
+  text-align: center;
+}
+.cards--right {
+  text-align: right;
+}
 .card__image {
   height: auto;
-  margin: 0 auto;
   max-width: 100%;
   padding: 0.7rem 10px;
+}
+.cards--center .card__image {
+  margin: 0 auto;
+}
+.cards--right .card__image {
+ margin: 0 0 0 auto;
 }
 
 .card__text {
   padding: 0 10px;
-  text-align: center;
   width: 100%;
 }

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -36,7 +36,7 @@
   {# Padding & margin #}
     {{ module.style.alignment_spacing.spacing.css }}
     {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.color }};
+        background-color: {{ module.style.background.bg_color.css }};
     {% endif %}
 
     {# Background styles #}

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -1,11 +1,4 @@
-{% set CARD_ALIGNMENT_CLASSES = {
-    'LEFT': 'cards--left',
-    'CENTER': 'cards--center',
-    'RIGHT': 'cards--right'
-  }
-%}
-
-<div class="cards {{ module.style.alignment_spacing.alignment.horizontal_align ? CARD_ALIGNMENT_CLASSES[module.style.alignment_spacing.alignment.horizontal_align] : CARD_ALIGNMENT_CLASSES['CENTER'] }}">
+<div class="cards">
   {% for card in module.card %}
     <section class="cards__card card">
       {% if card.image.src %}
@@ -20,47 +13,65 @@
       {% endif %}
       <div class="card__text">
         {% if card.title %}
-          <{{ card.title_heading_type }}>{{ card.title }}</{{ card.title_heading_type }}>
+          <{{ card.title_heading_type }} class="card__title">{{ card.title }}</{{ card.title_heading_type }}>
         {% endif %}
         {% if card.text %}
-          <p>{{ card.text }}</p>
+          <p class="card__content">{{ card.text }}</p>
         {% endif %}
       </div>
     </section>
   {% endfor %}
 </div>
 
-<style>
-{% scope_css %}
-  .card {
-  {# Padding & margin #}
-    {{ module.style.alignment_spacing.spacing.css }}
-    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.css }};
-    {% endif %}
+{# Module styles #}
 
-    {# Background styles #}
-    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
-      background: {{ module.style.background.bg_gradient.css }};
-    {% endif %}
-    {% if module.style.background.bg_type == "bg_image" %}
-      {{ module.style.background.bg_image.css }}
-    {% endif %}
+{% require_css %}
+  <style>
+    {% scope_css %}
 
-    {# Border #}
-    {{ module.style.border.css }}
+      /* Image */
 
-    {# Typography #}
-    {% if module.style.typography.font.size %}
-      font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
-    {% endif %}
-    {% if module.style.typography.font.color %}
-      color:{{module.style.typography.font.color}};
-    {% endif %}
-    {# Font style string is missing last semicolon #}
-    {% if  module.style.typography.font.style %}
-      {{ module.style.typography.font.style }};
-    {% endif %}
-  }
-{% end_scope_css%}
-</style>
+      {% if module.styles.image.corner.radius %}
+        .card__image {
+          border-radius: {{ module.styles.image.corner.radius ~ 'px' }};
+        }
+      {% endif %}
+
+      /* Title */
+
+      .card__title {
+        {{ module.styles.title.text.font.css }}
+        {% if module.styles.title.alignment.alignment.horizontal_align %}
+          text-align: {{ module.styles.title.alignment.alignment.horizontal_align }};
+        {% endif %}
+      }
+
+      /* Content */
+
+      .card__content {
+        {{ module.styles.content.text.font.css }}
+        {% if module.styles.content.alignment.alignment.horizontal_align %}
+          text-align: {{ module.styles.content.alignment.alignment.horizontal_align }};
+        {% endif %}
+      }
+
+      /* Card */
+
+      .card {
+        {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
+          background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
+        {% elif module.styles.card.background.background_type == "gradient" %}
+          {{ module.styles.card.background.gradient.css }}
+        {% elif module.styles.card.background.background_type == "image" %}
+          {{ module.styles.card.background.image.css }}
+        {% endif %}
+        {{ module.styles.card.border.border.css }}
+        {% if module.styles.card.corner.radius %}
+          border-radius: {{ module.styles.card.corner.radius ~ 'px' }};
+        {% endif %}
+        {{ module.styles.card.spacing.spacing.css }}
+      }
+
+    {% end_scope_css %}
+  </style>
+{% end_require_css %}

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -34,13 +34,15 @@
 {% scope_css %}
   .card {
     {{ module.style.alignment_spacing.spacing.css }}
-    {% if module.style.background.bg_color.color %}
-      background-color: {{ module.style.background.bg_color.color }};
+    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
+        background-color: {{ module.style.background.bg_color.color }};
     {% endif %}
-    {% if module.style.background.bg_gradient.css %}
+    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
       background: {{ module.style.background.bg_gradient.css }};
     {% endif %}
-    {{ module.style.background.bg_image.css }}
+    {% if module.style.background.bg_type == "bg_image" %}
+      {{ module.style.background.bg_image.css }}
+    {% endif %}
     {{ module.style.border.css }}
     {% if module.style.typography.font.size %}
       font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -1,4 +1,11 @@
-<div class="cards">
+{% set CARD_ALIGNMENT_CLASSES = {
+    'LEFT': 'cards--left',
+    'CENTER': 'cards--center',
+    'RIGHT': 'cards--right'
+  }
+%}
+
+<div class="cards {{ module.style.alignment_spacing.alignment.horizontal_align ? CARD_ALIGNMENT_CLASSES[module.style.alignment_spacing.alignment.horizontal_align] : CARD_ALIGNMENT_CLASSES['CENTER'] }}">
   {% for card in module.card %}
     <section class="cards__card card">
       {% if card.image.src %}
@@ -22,3 +29,29 @@
     </section>
   {% endfor %}
 </div>
+
+<style>
+{% scope_css %}
+  .card {
+    {{ module.style.alignment_spacing.spacing.css }}
+    {% if module.style.background.bg_color.color %}
+      background-color: {{ module.style.background.bg_color.color }};
+    {% endif %}
+    {% if module.style.background.bg_gradient.css %}
+      background: {{ module.style.background.bg_gradient.css }};
+    {% endif %}
+    {{ module.style.background.bg_image.css }}
+    {{ module.style.border.css }}
+    {% if module.style.typography.font.size %}
+      font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
+    {% endif %}
+    {% if module.style.typography.font.color %}
+      color:{{module.style.typography.font.color}};
+    {% endif %}
+    {# Font style string is missing last semicolon #}
+    {% if  module.style.typography.font.style %}
+      {{ module.style.typography.font.style }};
+    {% endif %}
+  }
+{% end_scope_css%}
+</style>

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -1,4 +1,9 @@
+{# Cards #}
+
 <div class="cards">
+
+  {# Loops through each card in the cards repeater #}
+
   {% for card in module.card %}
     <section class="cards__card card">
       {% if card.image.src %}
@@ -21,6 +26,7 @@
       </div>
     </section>
   {% endfor %}
+
 </div>
 
 {# Module styles #}
@@ -61,7 +67,7 @@
         {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
           background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
         {% elif module.styles.card.background.background_type == "gradient" %}
-          {{ module.styles.card.background.gradient.css }}
+          background: {{ module.styles.card.background.gradient.css }};
         {% elif module.styles.card.background.background_type == "image" %}
           {{ module.styles.card.background.image.css }}
         {% endif %}

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -1,3 +1,54 @@
+{# Module styles #}
+
+<style>
+  {% scope_css %}
+
+    /* Image */
+
+    {% if module.styles.image.corner.radius %}
+      .card__image {
+        border-radius: {{ module.styles.image.corner.radius ~ 'px' }};
+      }
+    {% endif %}
+
+    /* Title */
+
+    .card__title {
+      {{ module.styles.title.text.font.css }}
+      {% if module.styles.title.alignment.alignment.horizontal_align %}
+        text-align: {{ module.styles.title.alignment.alignment.horizontal_align }};
+      {% endif %}
+    }
+
+    /* Content */
+
+    .card__content {
+      {{ module.styles.content.text.font.css }}
+      {% if module.styles.content.alignment.alignment.horizontal_align %}
+        text-align: {{ module.styles.content.alignment.alignment.horizontal_align }};
+      {% endif %}
+    }
+
+    /* Card */
+
+    .card {
+      {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
+        background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
+      {% elif module.styles.card.background.background_type == "gradient" %}
+        background: {{ module.styles.card.background.gradient.css }};
+      {% elif module.styles.card.background.background_type == "image" %}
+        {{ module.styles.card.background.image.css }}
+      {% endif %}
+      {{ module.styles.card.border.border.css }}
+      {% if module.styles.card.corner.radius %}
+        border-radius: {{ module.styles.card.corner.radius ~ 'px' }};
+      {% endif %}
+      {{ module.styles.card.spacing.spacing.css }}
+    }
+
+  {% end_scope_css %}
+</style>
+
 {# Cards #}
 
 <div class="cards">
@@ -28,56 +79,3 @@
   {% endfor %}
 
 </div>
-
-{# Module styles #}
-
-{% require_css %}
-  <style>
-    {% scope_css %}
-
-      /* Image */
-
-      {% if module.styles.image.corner.radius %}
-        .card__image {
-          border-radius: {{ module.styles.image.corner.radius ~ 'px' }};
-        }
-      {% endif %}
-
-      /* Title */
-
-      .card__title {
-        {{ module.styles.title.text.font.css }}
-        {% if module.styles.title.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.title.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      /* Content */
-
-      .card__content {
-        {{ module.styles.content.text.font.css }}
-        {% if module.styles.content.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.content.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      /* Card */
-
-      .card {
-        {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
-          background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
-        {% elif module.styles.card.background.background_type == "gradient" %}
-          background: {{ module.styles.card.background.gradient.css }};
-        {% elif module.styles.card.background.background_type == "image" %}
-          {{ module.styles.card.background.image.css }}
-        {% endif %}
-        {{ module.styles.card.border.border.css }}
-        {% if module.styles.card.corner.radius %}
-          border-radius: {{ module.styles.card.corner.radius ~ 'px' }};
-        {% endif %}
-        {{ module.styles.card.spacing.spacing.css }}
-      }
-
-    {% end_scope_css %}
-  </style>
-{% end_require_css %}

--- a/src/modules/card-section.module/module.html
+++ b/src/modules/card-section.module/module.html
@@ -33,17 +33,24 @@
 <style>
 {% scope_css %}
   .card {
+  {# Padding & margin #}
     {{ module.style.alignment_spacing.spacing.css }}
     {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
         background-color: {{ module.style.background.bg_color.color }};
     {% endif %}
+
+    {# Background styles #}
     {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
       background: {{ module.style.background.bg_gradient.css }};
     {% endif %}
     {% if module.style.background.bg_type == "bg_image" %}
       {{ module.style.background.bg_image.css }}
     {% endif %}
+
+    {# Border #}
     {{ module.style.border.css }}
+
+    {# Typography #}
     {% if module.style.typography.font.size %}
       font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
     {% endif %}

--- a/src/modules/customizable-button.module/fields.json
+++ b/src/modules/customizable-button.module/fields.json
@@ -3,12 +3,7 @@
     "label": "Button link",
     "name": "link",
     "type": "link",
-    "supported_types": [
-      "EXTERNAL",
-      "CONTENT",
-      "FILE",
-      "EMAIL_ADDRESS"
-    ],
+    "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
     "default": {
       "url": {
         "href": "",
@@ -60,22 +55,10 @@
             "display": "radio",
             "type": "choice",
             "choices": [
-              [
-                "none",
-                "None"
-              ],
-              [
-                "bg_color",
-                "Background color"
-              ],
-              [
-                "bg_gradient",
-                "Background gradient"
-              ],
-              [
-                "bg_image",
-                "Background image"
-              ]
+              ["none", "None"],
+              ["bg_color", "Background color"],
+              ["bg_gradient", "Background gradient"],
+              ["bg_image", "Background image"]
             ],
             "default": "none"
           },

--- a/src/modules/customizable-button.module/fields.json
+++ b/src/modules/customizable-button.module/fields.json
@@ -1,23 +1,122 @@
 [
-  {
-    "label": "Button link",
-    "name": "link",
-    "type": "link",
-    "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
-    "default": {
-      "url": {
-        "href": "",
-        "type": "EXTERNAL"
-      },
-      "no_follow": false,
-      "open_in_new_tab": false
-    }
-  },
-  {
-    "label": "Button text",
-    "name": "button_text",
-    "type": "text",
-    "required": true,
-    "default": "Add a button link here"
+{
+  "label": "Button link",
+  "name": "link",
+  "type": "link",
+  "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
+  "default": {
+    "url": {
+      "href": "",
+      "type": "EXTERNAL"
+    },
+    "no_follow": false,
+    "open_in_new_tab": false
   }
+},
+{
+  "label": "Button text",
+  "name": "button_text",
+  "type": "text",
+  "required": true,
+  "default": "Add a button link here"
+},
+{
+  "label": "Style",
+  "name": "style",
+  "type": "group",
+  "tab": "STYLE",
+  "children": [
+    {
+      "label": "Alignment and spacing",
+      "name": "alignment_spacing",
+      "type": "Group",
+      "children": [
+        {
+          "label": "Alignment",
+          "name": "alignment",
+          "type": "alignment"
+        },
+        {
+          "label": "Spacing",
+          "name": "spacing",
+          "type": "spacing"
+        }
+      ]
+    },
+    {
+      "label": "Background",
+      "name": "background",
+      "type": "group",
+      "children": [
+        {
+          "label": "Background type",
+          "name": "bg_type",
+          "display": "radio",
+          "type": "choice",
+          "choices":[
+            ["none", "None"],
+            ["bg_color", "Background color"],
+            ["bg_gradient", "Background gradient"],
+            ["bg_image", "Background image"]
+          ],
+          "default": "none"
+        },
+        {
+          "label": "Background color",
+          "name": "bg_color",
+          "type": "color",
+          "visibility": {
+            "controlling_field": "style.background.bg_type",
+            "controlling_value_regex": "bg_color",
+            "operator": "EQUAL"
+          }
+        },
+        {
+          "label": "Background gradient",
+          "name": "bg_gradient",
+          "type": "gradient",
+          "visibility": {
+            "controlling_field": "style.background.bg_type",
+            "controlling_value_regex": "bg_gradient",
+            "operator": "EQUAL"
+          }
+        },
+        {
+          "label": "Background image",
+          "name": "bg_image",
+          "type": "image",
+          "visibility": {
+            "controlling_field": "style.background.bg_type",
+            "controlling_value_regex": "bg_image",
+            "operator": "EQUAL"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Border",
+      "name": "border",
+      "type": "group",
+      "children": [
+        {
+          "label": "Border",
+          "name": "border",
+          "type": "border"
+        }
+      ]
+    },
+    {
+      "label": "Typgraphy",
+      "name": "typography",
+      "type": "group",
+      "children": [
+        {
+          "label": "Font",
+          "name": "font",
+          "type": "font"
+        }
+      ]
+    }
+  ]
+}
 ]

--- a/src/modules/customizable-button.module/fields.json
+++ b/src/modules/customizable-button.module/fields.json
@@ -21,26 +21,20 @@
     "default": "Add a button link here"
   },
   {
-    "label": "Style",
-    "name": "style",
+    "label": "Styles",
+    "name": "styles",
     "type": "group",
     "tab": "STYLE",
     "children": [
       {
-        "label": "Alignment and spacing",
-        "name": "alignment_spacing",
-        "type": "Group",
+        "label": "Text",
+        "name": "text",
+        "type": "group",
         "children": [
           {
-            "label": "Alignment",
-            "name": "alignment",
-            "type": "alignment",
-            "alignment_direction": "HORIZONTAL"
-          },
-          {
-            "label": "Spacing",
-            "name": "spacing",
-            "type": "spacing"
+            "label": "Font",
+            "name": "font",
+            "type": "font"
           }
         ]
       },
@@ -50,64 +44,67 @@
         "type": "group",
         "children": [
           {
-            "label": "Background type",
-            "name": "bg_type",
-            "display": "radio",
-            "type": "choice",
-            "choices": [
-              ["none", "None"],
-              ["bg_color", "Background color"],
-              ["bg_gradient", "Background gradient"],
-              ["bg_image", "Background image"]
-            ],
-            "default": "none"
-          },
-          {
-            "label": "Background color",
-            "name": "bg_color",
-            "type": "color",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_color",
-              "operator": "EQUAL"
-            }
-          },
-          {
-            "label": "Background gradient",
-            "name": "bg_gradient",
-            "type": "gradient",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_gradient",
-              "operator": "EQUAL"
-            }
-          },
-          {
-            "label": "Background image",
-            "name": "bg_image",
-            "type": "backgroundimage",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_image",
-              "operator": "EQUAL"
-            }
+            "label": "Color",
+            "name": "color",
+            "type": "color"
           }
         ]
       },
       {
         "label": "Border",
         "name": "border",
-        "type": "border"
-      },
-      {
-        "label": "Typgraphy",
-        "name": "typography",
         "type": "group",
         "children": [
           {
-            "label": "Font",
-            "name": "font",
-            "type": "font"
+            "label" : "Border",
+            "name" : "border",
+            "type" : "border",
+            "visibility": {
+              "hidden_subfields": {
+                "border_radius": true
+              }
+            }
+          }
+        ]
+      },
+      {
+        "label": "Corner",
+        "name": "corner",
+        "type": "group",
+        "children": [
+          {
+            "label": "Radius",
+            "name": "radius",
+            "type": "number",
+            "display": "text",
+            "max": 100,
+            "step": 1,
+            "suffix": "px"
+          }
+        ]
+      },
+      {
+        "label": "Spacing",
+        "name": "spacing",
+        "type": "group",
+        "children": [
+          {
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "spacing"
+          }
+        ]
+      },
+      {
+        "label": "Alignment",
+        "name": "alignment",
+        "type": "group",
+        "children": [
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "alignment",
+            "alignment_direction": "HORIZONTAL"
           }
         ]
       }

--- a/src/modules/customizable-button.module/fields.json
+++ b/src/modules/customizable-button.module/fields.json
@@ -1,122 +1,133 @@
 [
-{
-  "label": "Button link",
-  "name": "link",
-  "type": "link",
-  "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
-  "default": {
-    "url": {
-      "href": "",
-      "type": "EXTERNAL"
-    },
-    "no_follow": false,
-    "open_in_new_tab": false
-  }
-},
-{
-  "label": "Button text",
-  "name": "button_text",
-  "type": "text",
-  "required": true,
-  "default": "Add a button link here"
-},
-{
-  "label": "Style",
-  "name": "style",
-  "type": "group",
-  "tab": "STYLE",
-  "children": [
-    {
-      "label": "Alignment and spacing",
-      "name": "alignment_spacing",
-      "type": "Group",
-      "children": [
-        {
-          "label": "Alignment",
-          "name": "alignment",
-          "type": "alignment"
-        },
-        {
-          "label": "Spacing",
-          "name": "spacing",
-          "type": "spacing"
-        }
-      ]
-    },
-    {
-      "label": "Background",
-      "name": "background",
-      "type": "group",
-      "children": [
-        {
-          "label": "Background type",
-          "name": "bg_type",
-          "display": "radio",
-          "type": "choice",
-          "choices":[
-            ["none", "None"],
-            ["bg_color", "Background color"],
-            ["bg_gradient", "Background gradient"],
-            ["bg_image", "Background image"]
-          ],
-          "default": "none"
-        },
-        {
-          "label": "Background color",
-          "name": "bg_color",
-          "type": "color",
-          "visibility": {
-            "controlling_field": "style.background.bg_type",
-            "controlling_value_regex": "bg_color",
-            "operator": "EQUAL"
-          }
-        },
-        {
-          "label": "Background gradient",
-          "name": "bg_gradient",
-          "type": "gradient",
-          "visibility": {
-            "controlling_field": "style.background.bg_type",
-            "controlling_value_regex": "bg_gradient",
-            "operator": "EQUAL"
-          }
-        },
-        {
-          "label": "Background image",
-          "name": "bg_image",
-          "type": "image",
-          "visibility": {
-            "controlling_field": "style.background.bg_type",
-            "controlling_value_regex": "bg_image",
-            "operator": "EQUAL"
-          }
-        }
-      ]
-    },
-    {
-      "label": "Border",
-      "name": "border",
-      "type": "group",
-      "children": [
-        {
-          "label": "Border",
-          "name": "border",
-          "type": "border"
-        }
-      ]
-    },
-    {
-      "label": "Typgraphy",
-      "name": "typography",
-      "type": "group",
-      "children": [
-        {
-          "label": "Font",
-          "name": "font",
-          "type": "font"
-        }
-      ]
+  {
+    "label": "Button link",
+    "name": "link",
+    "type": "link",
+    "supported_types": [
+      "EXTERNAL",
+      "CONTENT",
+      "FILE",
+      "EMAIL_ADDRESS"
+    ],
+    "default": {
+      "url": {
+        "href": "",
+        "type": "EXTERNAL"
+      },
+      "no_follow": false,
+      "open_in_new_tab": false
     }
-  ]
-}
+  },
+  {
+    "label": "Button text",
+    "name": "button_text",
+    "type": "text",
+    "required": true,
+    "default": "Add a button link here"
+  },
+  {
+    "label": "Style",
+    "name": "style",
+    "type": "group",
+    "tab": "STYLE",
+    "children": [
+      {
+        "label": "Alignment and spacing",
+        "name": "alignment_spacing",
+        "type": "Group",
+        "children": [
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "alignment",
+            "alignment_direction": "HORIZONTAL"
+          },
+          {
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "spacing"
+          }
+        ]
+      },
+      {
+        "label": "Background",
+        "name": "background",
+        "type": "group",
+        "children": [
+          {
+            "label": "Background type",
+            "name": "bg_type",
+            "display": "radio",
+            "type": "choice",
+            "choices": [
+              [
+                "none",
+                "None"
+              ],
+              [
+                "bg_color",
+                "Background color"
+              ],
+              [
+                "bg_gradient",
+                "Background gradient"
+              ],
+              [
+                "bg_image",
+                "Background image"
+              ]
+            ],
+            "default": "none"
+          },
+          {
+            "label": "Background color",
+            "name": "bg_color",
+            "type": "color",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_color",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background gradient",
+            "name": "bg_gradient",
+            "type": "gradient",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_gradient",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background image",
+            "name": "bg_image",
+            "type": "backgroundimage",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_image",
+              "operator": "EQUAL"
+            }
+          }
+        ]
+      },
+      {
+        "label": "Border",
+        "name": "border",
+        "type": "border"
+      },
+      {
+        "label": "Typgraphy",
+        "name": "typography",
+        "type": "group",
+        "children": [
+          {
+            "label": "Font",
+            "name": "font",
+            "type": "font"
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/src/modules/customizable-button.module/fields.json
+++ b/src/modules/customizable-button.module/fields.json
@@ -58,12 +58,7 @@
           {
             "label" : "Border",
             "name" : "border",
-            "type" : "border",
-            "visibility": {
-              "hidden_subfields": {
-                "border_radius": true
-              }
-            }
+            "type" : "border"
           }
         ]
       },

--- a/src/modules/customizable-button.module/meta.json
+++ b/src/modules/customizable-button.module/meta.json
@@ -1,5 +1,5 @@
 {
-  "label": "Customizable button",
+  "label": "Button",
   "css_assets": [],
   "external_js": [],
   "global": false,

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -1,25 +1,20 @@
-{% if module.link.url.type is equalto 'EMAIL_ADDRESS' %}
-  {% set href = 'mailto:' ~ module.link.url.href %}
-{% elif module.link.url.href == '/' %}
-  {% set href = module.link.url.href %}
-{% else %}
-  {% unless (module.link.url.href is string_containing '//') or !module.link.url.href %}
-    {% set href = '//' ~ module.link.url.href %}
-  {% else %}
-    {% set href = module.link.url.href || '' %}
-  {% endunless %}
-{% endif %}
+{# Sets attributes used for the link field #}
 
+{% set href = module.link.url.href %}
+{% if module.link.url.type is equalto 'EMAIL_ADDRESS' %}
+  {% set href = 'mailto:' + href %}
+{% endif %}
 {% set rel = [] %}
 {% if module.link.no_follow %}
-  {% do rel.append("nofollow") %}
+  {% do rel.append('nofollow') %}
 {% endif %}
 {% if module.link.open_in_new_tab %}
-  {% do rel.append("noopener") %}
+  {% do rel.append('noopener') %}
 {% endif %}
 
+{# Button #}
 
-<div class="button__wrapper">
+<div class="button-wrapper">
   <a class="button" href="{{ href }}"
   {% if module.link.open_in_new_tab %}target="_blank"{% endif %}
   {% if rel %}rel="{{ rel|join(' ') }}"{% endif %}
@@ -28,44 +23,34 @@
   </a>
 </div>
 
-<style>
-{% scope_css %}
-  .button__wrapper {
-    {# Alignment #}
-    {% if module.style.alignment_spacing.alignment.horizontal_align %}
-      text-align: {{ module.style.alignment_spacing.alignment.horizontal_align }};
-    {% endif %}
-  }
-  .button {
-  display: inline-block;
-    {# Padding & margin #}
-    {{ module.style.alignment_spacing.spacing.css }}
-    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.css }};
-    {% endif %}
+{# Module styles #}
 
-    {# Background styles #}
-    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
-      background: {{ module.style.background.bg_gradient.css }};
-    {% endif %}
-    {% if module.style.background.bg_type == "bg_image" %}
-      {{ module.style.background.bg_image.css }}
-    {% endif %}
+{% require_css %}
+  <style>
+    {% scope_css %}
 
-    {# Border #}
-    {{ module.style.border.css }}
+      /* Button wrapper */
 
-    {# Typography #}
-    {% if module.style.typography.font.size %}
-      font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
-    {% endif %}
-    {% if module.style.typography.font.color %}
-      color:{{module.style.typography.font.color}};
-    {% endif %}
-    {# Font style string is missing last semicolon #}
-    {% if  module.style.typography.font.style %}
-      {{ module.style.typography.font.style }};
-    {% endif %}
-  }
-{% end_scope_css%}
-</style>
+      {% if module.styles.alignment.alignment %}
+        .button-wrapper {
+          text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+        }
+      {% endif %}
+
+      /* Button */
+
+      .button {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+        {{ module.styles.border.border.css }}
+        {% if module.styles.corner.radius %}
+          border-radius: {{ module.styles.corner.radius ~ 'px' }};
+        {% endif %}
+        {{ module.styles.text.font.css }}
+        {{ module.styles.spacing.spacing.css }}
+      }
+
+    {% end_scope_css %}
+  </style>
+{% end_require_css %}

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -18,9 +18,54 @@
   {% do rel.append("noopener") %}
 {% endif %}
 
-<a class="button" href="{{ href }}"
-{% if module.link.open_in_new_tab %}target="_blank"{% endif %}
-{% if rel %}rel="{{ rel|join(' ') }}"{% endif %}
->
-  {{ module.button_text }}
-</a>
+
+<div class="button__wrapper">
+  <a class="button" href="{{ href }}"
+  {% if module.link.open_in_new_tab %}target="_blank"{% endif %}
+  {% if rel %}rel="{{ rel|join(' ') }}"{% endif %}
+  >
+    {{ module.button_text }}
+  </a>
+</div>
+
+<style>
+{% scope_css %}
+  .button__wrapper {
+    {# Alignment #}
+    {% if module.style.alignment_spacing.alignment.horizontal_align %}
+      text-align: {{ module.style.alignment_spacing.alignment.horizontal_align }};
+    {% endif %}
+  }
+  .button {
+  display: inline-block;
+    {# Padding & margin #}
+    {{ module.style.alignment_spacing.spacing.css }}
+    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
+        background-color: {{ module.style.background.bg_color.color }};
+    {% endif %}
+
+    {# Background styles #}
+    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
+      background: {{ module.style.background.bg_gradient.css }};
+    {% endif %}
+    {% if module.style.background.bg_type == "bg_image" %}
+      {{ module.style.background.bg_image.css }}
+    {% endif %}
+
+    {# Border #}
+    {{ module.style.border.css }}
+
+    {# Typography #}
+    {% if module.style.typography.font.size %}
+      font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
+    {% endif %}
+    {% if module.style.typography.font.color %}
+      color:{{module.style.typography.font.color}};
+    {% endif %}
+    {# Font style string is missing last semicolon #}
+    {% if  module.style.typography.font.style %}
+      {{ module.style.typography.font.style }};
+    {% endif %}
+  }
+{% end_scope_css%}
+</style>

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -41,7 +41,7 @@
     {# Padding & margin #}
     {{ module.style.alignment_spacing.spacing.css }}
     {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.color }};
+        background-color: {{ module.style.background.bg_color.css }};
     {% endif %}
 
     {# Background styles #}

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -51,6 +51,19 @@
         {{ module.styles.spacing.spacing.css }}
       }
 
+      .button:hover,
+      .button:focus {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+      }
+
+      .button:active {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+      }
+
     {% end_scope_css %}
   </style>
 {% end_require_css %}

--- a/src/modules/customizable-button.module/module.html
+++ b/src/modules/customizable-button.module/module.html
@@ -1,3 +1,46 @@
+{# Module styles #}
+
+<style>
+  {% scope_css %}
+
+    /* Button wrapper */
+
+    {% if module.styles.alignment.alignment %}
+      .button-wrapper {
+        text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+      }
+    {% endif %}
+
+    /* Button */
+
+    .button {
+      {% if module.styles.background.color.color %}
+        background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+      {% endif %}
+      {{ module.styles.border.border.css }}
+      {% if module.styles.corner.radius %}
+        border-radius: {{ module.styles.corner.radius ~ 'px' }};
+      {% endif %}
+      {{ module.styles.text.font.css }}
+      {{ module.styles.spacing.spacing.css }}
+    }
+
+    .button:hover,
+    .button:focus {
+      {% if module.styles.background.color.color %}
+        background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+      {% endif %}
+    }
+
+    .button:active {
+      {% if module.styles.background.color.color %}
+        background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+      {% endif %}
+    }
+
+  {% end_scope_css %}
+</style>
+
 {# Sets attributes used for the link field #}
 
 {% set href = module.link.url.href %}
@@ -22,48 +65,3 @@
     {{ module.button_text }}
   </a>
 </div>
-
-{# Module styles #}
-
-{% require_css %}
-  <style>
-    {% scope_css %}
-
-      /* Button wrapper */
-
-      {% if module.styles.alignment.alignment %}
-        .button-wrapper {
-          text-align: {{ module.styles.alignment.alignment.horizontal_align }};
-        }
-      {% endif %}
-
-      /* Button */
-
-      .button {
-        {% if module.styles.background.color.color %}
-          background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-        {% endif %}
-        {{ module.styles.border.border.css }}
-        {% if module.styles.corner.radius %}
-          border-radius: {{ module.styles.corner.radius ~ 'px' }};
-        {% endif %}
-        {{ module.styles.text.font.css }}
-        {{ module.styles.spacing.spacing.css }}
-      }
-
-      .button:hover,
-      .button:focus {
-        {% if module.styles.background.color.color %}
-          background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-        {% endif %}
-      }
-
-      .button:active {
-        {% if module.styles.background.color.color %}
-          background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-        {% endif %}
-      }
-
-    {% end_scope_css %}
-  </style>
-{% end_require_css %}

--- a/src/modules/pricing-card.module/fields.json
+++ b/src/modules/pricing-card.module/fields.json
@@ -293,12 +293,7 @@
               {
                 "label" : "Border",
                 "name" : "border",
-                "type" : "border",
-                "visibility": {
-                  "hidden_subfields": {
-                    "border_radius": true
-                  }
-                }
+                "type" : "border"
               }
             ]
           },
@@ -414,12 +409,7 @@
               {
                 "label": "Border",
                 "name": "border",
-                "type": "border",
-                "visibility": {
-                  "hidden_subfields": {
-                    "border_radius": true
-                  }
-                }
+                "type": "border"
               }
             ]
           },

--- a/src/modules/pricing-card.module/fields.json
+++ b/src/modules/pricing-card.module/fields.json
@@ -28,16 +28,20 @@
     "default": "h2"
   },
   {
-    "label": "Price",
-    "name": "price",
+    "label": "Product description",
+    "name": "description",
     "type": "text",
-    "default": "$0"
+    "default": "For teams that need additional security, control, and support."
   },
   {
-    "label": "Price timeframe",
-    "name": "timeframe",
-    "type": "text",
-    "default": "/ mo"
+    "label": "Features list icon",
+    "name": "feature_icon",
+    "type": "icon",
+    "default": {
+      "name": "check",
+      "type": "SOLID",
+      "unicode": "f00c"
+    }
   },
   {
     "label": "Features",
@@ -57,10 +61,16 @@
     ]
   },
   {
-    "label": "Button text",
-    "name": "button_text",
+    "label": "Price",
+    "name": "price",
     "type": "text",
-    "default": "Sign up for free"
+    "default": "$0"
+  },
+  {
+    "label": "Price timeframe",
+    "name": "timeframe",
+    "type": "text",
+    "default": "/ mo"
   },
   {
     "label": "Button link",
@@ -78,131 +88,368 @@
     }
   },
   {
-    "label": "Features list icon bullet",
-    "name": "feature_icon",
-    "type": "icon",
-    "default": {
-      "name": "check",
-      "type": "SOLID",
-      "unicode": "f00c"
-    }
-  },
-  {
-    "label": "Product description",
-    "name": "description",
+    "label": "Button text",
+    "name": "button_text",
     "type": "text",
-    "default": "For teams that need additional security, control, and support."
+    "default": "Sign up for free"
   },
   {
-    "label": "Button background color",
-    "name": "button_bg",
-    "type": "color",
-    "default": {
-      "color": "#494A52",
-      "opacity": 100
-    }
-  },
-  {
-    "label": "Button text color",
-    "name": "button_text_color",
-    "type": "color",
-    "visibility": {
-      "hidden_subfields": {
-        "opacity": true
-      }
-    },
-    "default": {
-      "color": "#FFFFFF"
-    }
-  },
-  {
-    "label": "Style",
-    "name": "style",
+    "label": "Styles",
+    "name": "styles",
     "type": "group",
     "tab": "STYLE",
     "children": [
       {
-        "label": "Alignment and spacing",
-        "name": "alignment_spacing",
-        "type": "Group",
+        "label": "Product tier",
+        "name": "product_tier",
+        "type": "group",
         "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
           {
             "label": "Alignment",
             "name": "alignment",
-            "type": "alignment",
-            "alignment_direction": "HORIZONTAL"
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Product description",
+        "name": "product_description",
+        "type": "group",
+        "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Features",
+        "name": "features",
+        "type": "group",
+        "children": [
+          {
+            "label": "Icon",
+            "name": "icon",
+            "type": "group",
+            "children": [
+              {
+                "label": "Color",
+                "name": "color",
+                "type": "color",
+                "visibility": {
+                  "hidden_subfields": {
+                    "opacity": true
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
+          {
+            "label": "Border",
+            "name": "border",
+            "type": "group",
+            "children": [
+              {
+                "label": "Color",
+                "name": "color",
+                "type": "color"
+              }
+            ]
+          },
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Price",
+        "name": "price",
+        "type": "group",
+        "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Button",
+        "name": "button",
+        "type": "group",
+        "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font"
+              }
+            ]
+          },
+          {
+            "label": "Background",
+            "name": "background",
+            "type": "group",
+            "children": [
+              {
+                "label": "Color",
+                "name": "color",
+                "type": "color"
+              }
+            ]
+          },
+          {
+            "label": "Border",
+            "name": "border",
+            "type": "group",
+            "children": [
+              {
+                "label" : "Border",
+                "name" : "border",
+                "type" : "border",
+                "visibility": {
+                  "hidden_subfields": {
+                    "border_radius": true
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "label": "Corner",
+            "name": "corner",
+            "type": "group",
+            "children": [
+              {
+                "label": "Radius",
+                "name": "radius",
+                "type": "number",
+                "display": "text",
+                "max": 100,
+                "step": 1,
+                "suffix": "px"
+              }
+            ]
           },
           {
             "label": "Spacing",
             "name": "spacing",
-            "type": "spacing"
+            "type": "group",
+            "children": [
+              {
+                "label": "Spacing",
+                "name": "spacing",
+                "type": "spacing",
+                "visibility": {
+                  "hidden_subfields": {
+                    "margin": true
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "group",
+            "children": [
+              {
+                "label": "Alignment",
+                "name": "alignment",
+                "type": "alignment",
+                "alignment_direction": "HORIZONTAL"
+              }
+            ]
           }
         ]
       },
       {
-        "label": "Background",
-        "name": "background",
+        "label": "Card",
+        "name": "card",
         "type": "group",
         "children": [
           {
-            "label": "Background type",
-            "name": "bg_type",
-            "display": "radio",
-            "type": "choice",
-            "choices": [
-              ["none", "None"],
-              ["bg_color", "Background color"],
-              ["bg_gradient", "Background gradient"],
-              ["bg_image", "Background image"]
-            ],
-            "default": "none"
+            "label": "Background",
+            "name": "background",
+            "type": "group",
+            "children": [
+              {
+                "label": "Background type",
+                "name": "background_type",
+                "id": "styles.card.background.background_type",
+                "type": "choice",
+                "choices": [
+                  ["none", "None"],
+                  ["color", "Background color"],
+                  ["gradient", "Background gradient"],
+                  ["image", "Background image"]
+                ],
+                "display": "radio",
+                "default": "none"
+              },
+              {
+                "label": "Color",
+                "name": "color",
+                "type": "color",
+                "visibility": {
+                  "controlling_field": "styles.card.background.background_type",
+                  "controlling_value_regex": "color",
+                  "operator": "EQUAL"
+                }
+              },
+              {
+                "label": "Gradient",
+                "name": "gradient",
+                "type": "gradient",
+                "visibility": {
+                  "controlling_field": "styles.card.background.background_type",
+                  "controlling_value_regex": "gradient",
+                  "operator": "EQUAL"
+                }
+              },
+              {
+                "label": "Image",
+                "name": "image",
+                "type": "backgroundimage",
+                "visibility": {
+                  "controlling_field": "styles.card.background.background_type",
+                  "controlling_value_regex": "image",
+                  "operator": "EQUAL"
+                }
+              }
+            ]
           },
           {
-            "label": "Background color",
-            "name": "bg_color",
-            "type": "color",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_color",
-              "operator": "EQUAL"
-            }
+            "label": "Border",
+            "name": "border",
+            "type": "group",
+            "children": [
+              {
+                "label": "Border",
+                "name": "border",
+                "type": "border",
+                "visibility": {
+                  "hidden_subfields": {
+                    "border_radius": true
+                  }
+                }
+              }
+            ]
           },
           {
-            "label": "Background gradient",
-            "name": "bg_gradient",
-            "type": "gradient",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_gradient",
-              "operator": "EQUAL"
-            }
+            "label": "Corner",
+            "name": "corner",
+            "type": "group",
+            "children": [
+              {
+                "label": "Radius",
+                "name": "radius",
+                "type": "number",
+                "display": "text",
+                "max": 100,
+                "step": 1,
+                "suffix": "px"
+              }
+            ]
           },
           {
-            "label": "Background image",
-            "name": "bg_image",
-            "type": "backgroundimage",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_image",
-              "operator": "EQUAL"
-            }
-          }
-        ]
-      },
-      {
-        "label": "Border",
-        "name": "border",
-        "type": "border"
-      },
-      {
-        "label": "Typgraphy",
-        "name": "typography",
-        "type": "group",
-        "children": [
-          {
-            "label": "Font",
-            "name": "font",
-            "type": "font"
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "group",
+            "children": [
+              {
+                "label": "Spacing",
+                "name": "spacing",
+                "type": "spacing"
+              }
+            ]
           }
         ]
       }

--- a/src/modules/pricing-card.module/fields.json
+++ b/src/modules/pricing-card.module/fields.json
@@ -107,5 +107,110 @@
     "default": {
       "color": "#FFFFFF"
     }
+  },
+  {
+    "label": "Style",
+    "name": "style",
+    "type": "group",
+    "tab": "STYLE",
+    "children": [
+      {
+        "label": "Alignment and spacing",
+        "name": "alignment_spacing",
+        "type": "Group",
+        "children": [
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "alignment",
+            "alignment_direction": "HORIZONTAL"
+          },
+          {
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "spacing"
+          }
+        ]
+      },
+      {
+        "label": "Background",
+        "name": "background",
+        "type": "group",
+        "children": [
+          {
+            "label": "Background type",
+            "name": "bg_type",
+            "display": "radio",
+            "type": "choice",
+            "choices": [
+              [
+                "none",
+                "None"
+              ],
+              [
+                "bg_color",
+                "Background color"
+              ],
+              [
+                "bg_gradient",
+                "Background gradient"
+              ],
+              [
+                "bg_image",
+                "Background image"
+              ]
+            ],
+            "default": "none"
+          },
+          {
+            "label": "Background color",
+            "name": "bg_color",
+            "type": "color",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_color",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background gradient",
+            "name": "bg_gradient",
+            "type": "gradient",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_gradient",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background image",
+            "name": "bg_image",
+            "type": "backgroundimage",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_image",
+              "operator": "EQUAL"
+            }
+          }
+        ]
+      },
+      {
+        "label": "Border",
+        "name": "border",
+        "type": "border"
+      },
+      {
+        "label": "Typgraphy",
+        "name": "typography",
+        "type": "group",
+        "children": [
+          {
+            "label": "Font",
+            "name": "font",
+            "type": "font"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/src/modules/pricing-card.module/fields.json
+++ b/src/modules/pricing-card.module/fields.json
@@ -10,9 +10,16 @@
     "label": "Product tier heading type",
     "name": "tier_heading_type",
     "type": "choice",
-    "choices": [["h1", "Heading 1"], ["h2", "Heading 2"], ["h3", "Heading 3"], ["h4", "Heading 4"], ["h5", "Heading 5"], ["h6", "Heading 6"]],
+    "choices": [
+      ["h1", "Heading 1"],
+      ["h2", "Heading 2"],
+      ["h3", "Heading 3"],
+      ["h4", "Heading 4"],
+      ["h5", "Heading 5"],
+      ["h6", "Heading 6"]
+    ],
     "display": "select",
-    "required" : true,
+    "required": true,
     "visibility": {
       "controlling_field": "tier",
       "controlling_value_regex": "",
@@ -143,22 +150,10 @@
             "display": "radio",
             "type": "choice",
             "choices": [
-              [
-                "none",
-                "None"
-              ],
-              [
-                "bg_color",
-                "Background color"
-              ],
-              [
-                "bg_gradient",
-                "Background gradient"
-              ],
-              [
-                "bg_image",
-                "Background image"
-              ]
+              ["none", "None"],
+              ["bg_color", "Background color"],
+              ["bg_gradient", "Background gradient"],
+              ["bg_image", "Background image"]
             ],
             "default": "none"
           },

--- a/src/modules/pricing-card.module/module.css
+++ b/src/modules/pricing-card.module/module.css
@@ -1,11 +1,13 @@
-.card--pricing {
+.card {
+  text-align: center;
+}
+.card__pricing {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.15);
   padding: 2rem;
-  text-align: center;
+
 }
 
 .card__header {
-  text-align: center;
 }
 
 .card__subtitle,

--- a/src/modules/pricing-card.module/module.css
+++ b/src/modules/pricing-card.module/module.css
@@ -4,10 +4,18 @@
 .card__pricing {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.15);
   padding: 2rem;
-
 }
 
-.card__header {
+@media screen and (max-width: 1200px) {
+  .card--pricing {
+    padding: 2rem 1rem;
+  }
+}
+
+@media screen and (max-width: 787px) {
+  .card--pricing {
+    margin-bottom: 1rem;
+  }
 }
 
 .card__subtitle,
@@ -30,19 +38,13 @@
 
 .card__body svg {
   display: inline-block;
-  fill: #494A52;
+  fill: #494a52;
   margin-right: 10px;
   max-width: 20px;
 }
 
-@media screen and (max-width: 1200px) {
-  .card--pricing {
-    padding: 2rem 1rem;
-  }
+.card__button {
+  background-color: #494a52;
+  color: #fff;
 }
 
-@media screen and (max-width: 787px) {
-  .card--pricing {
-    margin-bottom: 1rem;
-  }
-}

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -58,7 +58,7 @@
     {# Padding & margin #}
     {{ module.style.alignment_spacing.spacing.css }}
     {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.color }};
+        background-color: {{ module.style.background.bg_color.css }};
     {% endif %}
 
     {# Background styles #}
@@ -77,7 +77,7 @@
       font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
     {% endif %}
     {% if module.style.typography.font.color %}
-      color:{{module.style.typography.font.color}};
+      color: {{module.style.typography.font.color}};
     {% endif %}
     {# Font style string is missing last semicolon #}
     {% if  module.style.typography.font.style %}

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -1,14 +1,3 @@
-{%- macro inlineDynamicButtonStyles(styleDict) -%}
-  {%- for prop, value in styleDict.items() -%}
-    {{ prop|replace('_', '-') ~ ': ' ~ value ~ ( loop.last ? '' : '; ') }}
-  {%- endfor -%}
-{%- endmacro -%}
-{%- set buttonStyles = {
-    background_color: module.button_bg.color,
-    color: module.button_text_color.color
-  }
--%}
-
 {% set href = module.button_link.url.href %}
 {% if module.button_link.url.type is equalto "EMAIL_ADDRESS" %}
 	{% set href = "mailto:" + href %}
@@ -50,7 +39,6 @@
     <hr>
     <p class="card__price">{{ module.price }}</p>
     <a class="button"
-    style="{{ inlineDynamicButtonStyles(buttonStyles) }}"
     href="{{ href }}"
     {% if module.button_link.open_in_new_tab %}target="_blank"{% endif %}
     {% if rel %}rel="{{ rel|join(" ") }}"{% endif %}>
@@ -58,3 +46,43 @@
     </a>
   </div>
 </section>
+
+<style>
+{% scope_css %}
+  .card {
+    {# Alignment #}
+    {% if module.style.alignment_spacing.alignment.horizontal_align %}
+      text-align: {{ module.style.alignment_spacing.alignment.horizontal_align }};
+    {% endif %}
+
+    {# Padding & margin #}
+    {{ module.style.alignment_spacing.spacing.css }}
+    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
+        background-color: {{ module.style.background.bg_color.color }};
+    {% endif %}
+
+    {# Background styles #}
+    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
+      background: {{ module.style.background.bg_gradient.css }};
+    {% endif %}
+    {% if module.style.background.bg_type == "bg_image" %}
+      {{ module.style.background.bg_image.css }}
+    {% endif %}
+
+    {# Border #}
+    {{ module.style.border.css }}
+
+    {# Typography #}
+    {% if module.style.typography.font.size %}
+      font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
+    {% endif %}
+    {% if module.style.typography.font.color %}
+      color:{{module.style.typography.font.color}};
+    {% endif %}
+    {# Font style string is missing last semicolon #}
+    {% if  module.style.typography.font.style %}
+      {{ module.style.typography.font.style }};
+    {% endif %}
+  }
+{% end_scope_css%}
+</style>

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -128,6 +128,19 @@
         {{ module.styles.button.spacing.spacing.css }}
       }
 
+      .button:hover,
+      .button:focus {
+        {% if module.styles.button.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.button.background.color.color, -80)|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
+        {% endif %}
+      }
+
+      .button:active {
+        {% if module.styles.button.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.button.background.color.color, 80)|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
+        {% endif %}
+      }
+
       /* Card */
 
       .card {

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -1,3 +1,111 @@
+{# Module styles #}
+
+<style>
+  {% scope_css %}
+
+    /* Product tier */
+
+    .card__heading {
+      {{ module.styles.product_tier.text.font.css }}
+      {% if module.styles.product_tier.alignment.alignment.horizontal_align %}
+        text-align: {{ module.styles.product_tier.alignment.alignment.horizontal_align }};
+      {% endif %}
+    }
+
+    /* Product description */
+
+    .card__subtitle {
+      {{ module.styles.product_description.text.font.css }}
+      {% if module.styles.product_description.alignment.alignment.horizontal_align %}
+        text-align: {{ module.styles.product_description.alignment.alignment.horizontal_align }};
+      {% endif %}
+    }
+
+    /* Features */
+
+    .card__hr {
+      background-color: rgba({{ module.styles.features.border.color.color|convert_rgb }}, {{ module.styles.features.border.color.opacity / 100 }});
+      color: rgba({{ module.styles.features.border.color.color|convert_rgb }}, {{ module.styles.features.border.color.opacity / 100 }});
+    }
+
+    {% if module.styles.features.alignment.alignment.horizontal_align %}
+      .card__features {
+        text-align: {{ module.styles.features.alignment.alignment.horizontal_align }};
+      }
+    {% endif %}
+
+    .card__feature-item {
+      {{ module.styles.features.text.font.css }}
+    }
+
+    .card__icon svg {
+      fill: {{ module.styles.features.icon.color.color }};
+    }
+
+    /* Price */
+
+    .card__price {
+      {{ module.styles.price.text.font.css }}
+      {% if module.styles.price.alignment.alignment.horizontal_align %}
+        text-align: {{ module.styles.price.alignment.alignment.horizontal_align }};
+      {% endif %}
+    }
+
+    /* Button wrapper */
+
+    {% if module.styles.button.alignment.alignment %}
+      .button-wrapper {
+        text-align: {{ module.styles.button.alignment.alignment.horizontal_align }};
+      }
+    {% endif %}
+
+    /* Button */
+
+    .button {
+      {% if module.styles.button.background.color.color %}
+        background-color: rgba({{ module.styles.button.background.color.color|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
+      {% endif %}
+      {{ module.styles.button.border.border.css }}
+      {% if module.styles.button.corner.radius %}
+        border-radius: {{ module.styles.button.corner.radius ~ 'px' }};
+      {% endif %}
+      {{ module.styles.button.text.font.css }}
+      {{ module.styles.button.spacing.spacing.css }}
+    }
+
+    .button:hover,
+    .button:focus {
+      {% if module.styles.button.background.color.color %}
+        background-color: rgba({{ color_variant(module.styles.button.background.color.color, -80)|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
+      {% endif %}
+    }
+
+    .button:active {
+      {% if module.styles.button.background.color.color %}
+        background-color: rgba({{ color_variant(module.styles.button.background.color.color, 80)|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
+      {% endif %}
+    }
+
+    /* Card */
+
+    .card {
+      {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
+        background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
+      {% elif module.styles.card.background.background_type == "gradient" %}
+        background: {{ module.styles.card.background.gradient.css }};
+      {% elif module.styles.card.background.background_type == "image" %}
+        {{ module.styles.card.background.image.css }}
+      {% endif %}
+      {{ module.styles.card.border.border.css }}
+      {% if module.styles.card.corner.radius %}
+        border-radius: {{ module.styles.card.corner.radius ~ 'px' }};
+      {% endif %}
+      {{ module.styles.card.spacing.spacing.css }}
+    }
+
+  {% end_scope_css %}
+</style>
+
 {# Sets attributes used for the link field #}
 
 {% set href = module.button_link.url.href %}
@@ -51,113 +159,3 @@
     </div>
   </div>
 </section>
-
-{# Module styles #}
-
-{% require_css %}
-  <style>
-    {% scope_css %}
-
-      /* Product tier */
-
-      .card__heading {
-        {{ module.styles.product_tier.text.font.css }}
-        {% if module.styles.product_tier.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.product_tier.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      /* Product description */
-
-      .card__subtitle {
-        {{ module.styles.product_description.text.font.css }}
-        {% if module.styles.product_description.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.product_description.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      /* Features */
-
-      .card__hr {
-        background-color: rgba({{ module.styles.features.border.color.color|convert_rgb }}, {{ module.styles.features.border.color.opacity / 100 }});
-        color: rgba({{ module.styles.features.border.color.color|convert_rgb }}, {{ module.styles.features.border.color.opacity / 100 }});
-      }
-
-      {% if module.styles.features.alignment.alignment.horizontal_align %}
-        .card__features {
-          text-align: {{ module.styles.features.alignment.alignment.horizontal_align }};
-        }
-      {% endif %}
-
-      .card__feature-item {
-        {{ module.styles.features.text.font.css }}
-      }
-
-      .card__icon svg {
-        fill: {{ module.styles.features.icon.color.color }};
-      }
-
-      /* Price */
-
-      .card__price {
-        {{ module.styles.price.text.font.css }}
-        {% if module.styles.price.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.price.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      /* Button wrapper */
-
-      {% if module.styles.button.alignment.alignment %}
-        .button-wrapper {
-          text-align: {{ module.styles.button.alignment.alignment.horizontal_align }};
-        }
-      {% endif %}
-
-      /* Button */
-
-      .button {
-        {% if module.styles.button.background.color.color %}
-          background-color: rgba({{ module.styles.button.background.color.color|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
-        {% endif %}
-        {{ module.styles.button.border.border.css }}
-        {% if module.styles.button.corner.radius %}
-          border-radius: {{ module.styles.button.corner.radius ~ 'px' }};
-        {% endif %}
-        {{ module.styles.button.text.font.css }}
-        {{ module.styles.button.spacing.spacing.css }}
-      }
-
-      .button:hover,
-      .button:focus {
-        {% if module.styles.button.background.color.color %}
-          background-color: rgba({{ color_variant(module.styles.button.background.color.color, -80)|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
-        {% endif %}
-      }
-
-      .button:active {
-        {% if module.styles.button.background.color.color %}
-          background-color: rgba({{ color_variant(module.styles.button.background.color.color, 80)|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
-        {% endif %}
-      }
-
-      /* Card */
-
-      .card {
-        {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
-          background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
-        {% elif module.styles.card.background.background_type == "gradient" %}
-          background: {{ module.styles.card.background.gradient.css }};
-        {% elif module.styles.card.background.background_type == "image" %}
-          {{ module.styles.card.background.image.css }}
-        {% endif %}
-        {{ module.styles.card.border.border.css }}
-        {% if module.styles.card.corner.radius %}
-          border-radius: {{ module.styles.card.corner.radius ~ 'px' }};
-        {% endif %}
-        {{ module.styles.card.spacing.spacing.css }}
-      }
-
-    {% end_scope_css %}
-  </style>
-{% end_require_css %}

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -1,14 +1,18 @@
+{# Sets attributes used for the link field #}
+
 {% set href = module.button_link.url.href %}
-{% if module.button_link.url.type is equalto "EMAIL_ADDRESS" %}
-	{% set href = "mailto:" + href %}
+{% if module.button_link.url.type is equalto 'EMAIL_ADDRESS' %}
+  {% set href = 'mailto:' + href %}
 {% endif %}
 {% set rel = [] %}
 {% if module.button_link.no_follow %}
-	{% do rel.append("nofollow") %}
+  {% do rel.append('nofollow') %}
 {% endif %}
 {% if module.button_link.open_in_new_tab %}
-	{% do rel.append("noopener") %}
+  {% do rel.append('noopener') %}
 {% endif %}
+
+{# Pricing card #}
 
 <section class="card card--pricing">
   {% if module.tier and module.description %}
@@ -21,68 +25,126 @@
       {% endif %}
     </div>
   {% endif %}
-  <hr>
+  <hr class="card__hr">
   <div class="card__body">
-    <ul>
+    <ul class="card__features">
       {% for feature in module.features %}
-        <li>
+        <li class="card__feature-item">
           {% icon
-            name='{{ module.feature_icon.name }}'
-            purpose='decorative'
-            style='{{ module.feature_icon.type }}'
+            extra_classes='card__icon',
+            name='{{ module.feature_icon.name }}',
+            purpose='decorative',
+            style='{{ module.feature_icon.type }}',
             unicode='{{ module.feature_icon.unicode }}'
-            no_wrapper=True
           %}{{ feature }}
         </li>
       {% endfor %}
     </ul>
-    <hr>
-    <p class="card__price">{{ module.price }}</p>
-    <a class="button"
-    href="{{ href }}"
-    {% if module.button_link.open_in_new_tab %}target="_blank"{% endif %}
-    {% if rel %}rel="{{ rel|join(" ") }}"{% endif %}>
-      {{ module.button_text }}
-    </a>
+    <hr class="card__hr">
+    <p class="card__price">{{ module.price }}{{ module.timeframe }}</p>
+    <div class="card__button-wrapper button-wrapper">
+      <a class="card__button button" href="{{ href }}"
+        {% if module.button_link.open_in_new_tab %}target="_blank"{% endif %}
+        {% if rel %}rel="{{ rel|join(' ') }}"{% endif %}>
+          {{ module.button_text }}
+      </a>
+    </div>
   </div>
 </section>
 
-<style>
-{% scope_css %}
-  .card {
-    {# Alignment #}
-    {% if module.style.alignment_spacing.alignment.horizontal_align %}
-      text-align: {{ module.style.alignment_spacing.alignment.horizontal_align }};
-    {% endif %}
+{# Module styles #}
 
-    {# Padding & margin #}
-    {{ module.style.alignment_spacing.spacing.css }}
-    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.css }};
-    {% endif %}
+{% require_css %}
+  <style>
+    {% scope_css %}
 
-    {# Background styles #}
-    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
-      background: {{ module.style.background.bg_gradient.css }};
-    {% endif %}
-    {% if module.style.background.bg_type == "bg_image" %}
-      {{ module.style.background.bg_image.css }}
-    {% endif %}
+      /* Product tier */
 
-    {# Border #}
-    {{ module.style.border.css }}
+      .card__heading {
+        {{ module.styles.product_tier.text.font.css }}
+        {% if module.styles.product_tier.alignment.alignment.horizontal_align %}
+          text-align: {{ module.styles.product_tier.alignment.alignment.horizontal_align }};
+        {% endif %}
+      }
 
-    {# Typography #}
-    {% if module.style.typography.font.size %}
-      font-size:{{module.style.typography.font.size.value}}{{module.style.typography.font.size.units}};
-    {% endif %}
-    {% if module.style.typography.font.color %}
-      color: {{module.style.typography.font.color}};
-    {% endif %}
-    {# Font style string is missing last semicolon #}
-    {% if  module.style.typography.font.style %}
-      {{ module.style.typography.font.style }};
-    {% endif %}
-  }
-{% end_scope_css%}
-</style>
+      /* Product description */
+
+      .card__subtitle {
+        {{ module.styles.product_description.text.font.css }}
+        {% if module.styles.product_description.alignment.alignment.horizontal_align %}
+          text-align: {{ module.styles.product_description.alignment.alignment.horizontal_align }};
+        {% endif %}
+      }
+
+      /* Features */
+
+      .card__hr {
+        background-color: rgba({{ module.styles.features.border.color.color|convert_rgb }}, {{ module.styles.features.border.color.opacity / 100 }});
+        color: rgba({{ module.styles.features.border.color.color|convert_rgb }}, {{ module.styles.features.border.color.opacity / 100 }});
+      }
+
+      {% if module.styles.features.alignment.alignment.horizontal_align %}
+        .card__features {
+          text-align: {{ module.styles.features.alignment.alignment.horizontal_align }};
+        }
+      {% endif %}
+
+      .card__feature-item {
+        {{ module.styles.features.text.font.css }}
+      }
+
+      .card__icon svg {
+        fill: {{ module.styles.features.icon.color.color }};
+      }
+
+      /* Price */
+
+      .card__price {
+        {{ module.styles.price.text.font.css }}
+        {% if module.styles.price.alignment.alignment.horizontal_align %}
+          text-align: {{ module.styles.price.alignment.alignment.horizontal_align }};
+        {% endif %}
+      }
+
+      /* Button wrapper */
+
+      {% if module.styles.button.alignment.alignment %}
+        .button-wrapper {
+          text-align: {{ module.styles.button.alignment.alignment.horizontal_align }};
+        }
+      {% endif %}
+
+      /* Button */
+
+      .button {
+        {% if module.styles.button.background.color.color %}
+          background-color: rgba({{ module.styles.button.background.color.color|convert_rgb }}, {{ module.styles.button.background.color.opacity / 100 }});
+        {% endif %}
+        {{ module.styles.button.border.border.css }}
+        {% if module.styles.button.corner.radius %}
+          border-radius: {{ module.styles.button.corner.radius ~ 'px' }};
+        {% endif %}
+        {{ module.styles.button.text.font.css }}
+        {{ module.styles.button.spacing.spacing.css }}
+      }
+
+      /* Card */
+
+      .card {
+        {% if module.styles.card.background.background_type == "color" && module.styles.card.background.color.color %}
+          background-color: rgba({{ module.styles.card.background.color.color|convert_rgb }}, {{ module.styles.card.background.color.opacity / 100 }});
+        {% elif module.styles.card.background.background_type == "gradient" %}
+          background: {{ module.styles.card.background.gradient.css }};
+        {% elif module.styles.card.background.background_type == "image" %}
+          {{ module.styles.card.background.image.css }}
+        {% endif %}
+        {{ module.styles.card.border.border.css }}
+        {% if module.styles.card.corner.radius %}
+          border-radius: {{ module.styles.card.corner.radius ~ 'px' }};
+        {% endif %}
+        {{ module.styles.card.spacing.spacing.css }}
+      }
+
+    {% end_scope_css %}
+  </style>
+{% end_require_css %}

--- a/src/modules/social-follow.module/fields.json
+++ b/src/modules/social-follow.module/fields.json
@@ -14,16 +14,46 @@
         "id": "social_account",
         "type": "choice",
         "choices": [
-          ["facebook-f", "Facebook"],
-          ["twitter", "Twitter"],
-          ["instagram", "Instagram"],
-          ["linkedin-in", "LinkedIn"],
-          ["youtube", "YouTube"],
-          ["pinterest-p", "Pinterest"],
-          ["envelope", "Email"],
-          ["link", "Website"],
-          ["whatsapp", "Whatsapp"],
-          ["custom_icon", "Custom icon"]
+          [
+            "facebook-f",
+            "Facebook"
+          ],
+          [
+            "twitter",
+            "Twitter"
+          ],
+          [
+            "instagram",
+            "Instagram"
+          ],
+          [
+            "linkedin-in",
+            "LinkedIn"
+          ],
+          [
+            "youtube",
+            "YouTube"
+          ],
+          [
+            "pinterest-p",
+            "Pinterest"
+          ],
+          [
+            "envelope",
+            "Email"
+          ],
+          [
+            "link",
+            "Website"
+          ],
+          [
+            "whatsapp",
+            "Whatsapp"
+          ],
+          [
+            "custom_icon",
+            "Custom icon"
+          ]
         ],
         "display": "select",
         "required": true,
@@ -48,7 +78,10 @@
         "name": "social_link",
         "type": "link",
         "required": true,
-        "supported_types": ["EXTERNAL", "EMAIL_ADDRESS"],
+        "supported_types": [
+          "EXTERNAL",
+          "EMAIL_ADDRESS"
+        ],
         "default": {
           "no_follow": false,
           "open_in_new_tab": true,
@@ -134,6 +167,99 @@
         "accessibility": {
           "title": "Follow us on Instagram"
         }
+      }
+    ]
+  },
+  {
+    "label": "Style",
+    "name": "style",
+    "type": "group",
+    "tab": "STYLE",
+    "children": [
+      {
+        "label": "Alignment and spacing",
+        "name": "alignment_spacing",
+        "type": "Group",
+        "children": [
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "alignment",
+            "alignment_direction": "HORIZONTAL"
+          },
+          {
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "spacing"
+          }
+        ]
+      },
+      {
+        "label": "Background",
+        "name": "background",
+        "type": "group",
+        "children": [
+          {
+            "label": "Background type",
+            "name": "bg_type",
+            "display": "radio",
+            "type": "choice",
+            "choices": [
+              [
+                "none",
+                "None"
+              ],
+              [
+                "bg_color",
+                "Background color"
+              ],
+              [
+                "bg_gradient",
+                "Background gradient"
+              ],
+              [
+                "bg_image",
+                "Background image"
+              ]
+            ],
+            "default": "none"
+          },
+          {
+            "label": "Background color",
+            "name": "bg_color",
+            "type": "color",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_color",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background gradient",
+            "name": "bg_gradient",
+            "type": "gradient",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_gradient",
+              "operator": "EQUAL"
+            }
+          },
+          {
+            "label": "Background image",
+            "name": "bg_image",
+            "type": "backgroundimage",
+            "visibility": {
+              "controlling_field": "style.background.bg_type",
+              "controlling_value_regex": "bg_image",
+              "operator": "EQUAL"
+            }
+          }
+        ]
+      },
+      {
+        "label": "Border",
+        "name": "border",
+        "type": "border"
       }
     ]
   }

--- a/src/modules/social-follow.module/fields.json
+++ b/src/modules/social-follow.module/fields.json
@@ -14,46 +14,16 @@
         "id": "social_account",
         "type": "choice",
         "choices": [
-          [
-            "facebook-f",
-            "Facebook"
-          ],
-          [
-            "twitter",
-            "Twitter"
-          ],
-          [
-            "instagram",
-            "Instagram"
-          ],
-          [
-            "linkedin-in",
-            "LinkedIn"
-          ],
-          [
-            "youtube",
-            "YouTube"
-          ],
-          [
-            "pinterest-p",
-            "Pinterest"
-          ],
-          [
-            "envelope",
-            "Email"
-          ],
-          [
-            "link",
-            "Website"
-          ],
-          [
-            "whatsapp",
-            "Whatsapp"
-          ],
-          [
-            "custom_icon",
-            "Custom icon"
-          ]
+          ["facebook-f", "Facebook"],
+          ["twitter", "Twitter"],
+          ["instagram", "Instagram"],
+          ["linkedin-in", "LinkedIn"],
+          ["youtube", "YouTube"],
+          ["pinterest-p", "Pinterest"],
+          ["envelope", "Email"],
+          ["link", "Website"],
+          ["whatsapp", "Whatsapp"],
+          ["custom_icon", "Custom icon"]
         ],
         "display": "select",
         "required": true,
@@ -78,10 +48,7 @@
         "name": "social_link",
         "type": "link",
         "required": true,
-        "supported_types": [
-          "EXTERNAL",
-          "EMAIL_ADDRESS"
-        ],
+        "supported_types": ["EXTERNAL", "EMAIL_ADDRESS"],
         "default": {
           "no_follow": false,
           "open_in_new_tab": true,
@@ -205,22 +172,10 @@
             "display": "radio",
             "type": "choice",
             "choices": [
-              [
-                "none",
-                "None"
-              ],
-              [
-                "bg_color",
-                "Background color"
-              ],
-              [
-                "bg_gradient",
-                "Background gradient"
-              ],
-              [
-                "bg_image",
-                "Background image"
-              ]
+              ["none", "None"],
+              ["bg_color", "Background color"],
+              ["bg_gradient", "Background gradient"],
+              ["bg_image", "Background image"]
             ],
             "default": "none"
           },

--- a/src/modules/social-follow.module/fields.json
+++ b/src/modules/social-follow.module/fields.json
@@ -138,26 +138,42 @@
     ]
   },
   {
-    "label": "Style",
-    "name": "style",
+    "label": "Styles",
+    "name": "styles",
     "type": "group",
     "tab": "STYLE",
     "children": [
       {
-        "label": "Alignment and spacing",
-        "name": "alignment_spacing",
-        "type": "Group",
+        "label": "Fill",
+        "name": "fill",
+        "type": "group",
         "children": [
           {
-            "label": "Alignment",
-            "name": "alignment",
-            "type": "alignment",
-            "alignment_direction": "HORIZONTAL"
-          },
+            "label": "Color",
+            "name": "color",
+            "type": "color",
+            "visibility": {
+              "hidden_subfields": {
+                "opacity": true
+              }
+            }
+          }
+        ]
+      },
+      {
+        "label": "Size",
+        "name": "size",
+        "type": "group",
+        "children": [
           {
-            "label": "Spacing",
-            "name": "spacing",
-            "type": "spacing"
+            "label": "Size",
+            "name": "size",
+            "type": "number",
+            "display": "text",
+            "max": 50,
+            "min": 1,
+            "step": 1,
+            "suffix": "px"
           }
         ]
       },
@@ -167,54 +183,62 @@
         "type": "group",
         "children": [
           {
-            "label": "Background type",
-            "name": "bg_type",
-            "display": "radio",
-            "type": "choice",
-            "choices": [
-              ["none", "None"],
-              ["bg_color", "Background color"],
-              ["bg_gradient", "Background gradient"],
-              ["bg_image", "Background image"]
-            ],
-            "default": "none"
-          },
-          {
-            "label": "Background color",
-            "name": "bg_color",
-            "type": "color",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_color",
-              "operator": "EQUAL"
-            }
-          },
-          {
-            "label": "Background gradient",
-            "name": "bg_gradient",
-            "type": "gradient",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_gradient",
-              "operator": "EQUAL"
-            }
-          },
-          {
-            "label": "Background image",
-            "name": "bg_image",
-            "type": "backgroundimage",
-            "visibility": {
-              "controlling_field": "style.background.bg_type",
-              "controlling_value_regex": "bg_image",
-              "operator": "EQUAL"
-            }
+            "label": "Color",
+            "name": "color",
+            "type": "color"
           }
         ]
       },
       {
-        "label": "Border",
-        "name": "border",
-        "type": "border"
+        "label": "Corner",
+        "name": "corner",
+        "type": "group",
+        "children": [
+          {
+            "label": "Radius",
+            "name": "radius",
+            "type": "number",
+            "display": "text",
+            "max": 100,
+            "step": 1,
+            "suffix": "px"
+          }
+        ]
+      },
+      {
+        "label": "Spacing",
+        "name": "spacing",
+        "type": "group",
+        "children": [
+          {
+            "label": "Space between icons",
+            "name": "space_between_icons",
+            "type": "number",
+            "display": "slider",
+            "max": 50,
+            "min": 0,
+            "step": 5,
+            "suffix": "px"
+          },
+          {
+            "label": "Spacing",
+            "name": "spacing",
+            "type": "spacing"
+          }
+        ]
+      },
+      {
+        "label": "Alignment",
+        "name": "alignment",
+        "type": "group",
+        "children": [
+          {
+            "label": "Alignment",
+            "name": "alignment",
+            "type": "alignment",
+            "alignment_direction": "HORIZONTAL"
+          }
+        ]
       }
     ]
   }

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -32,3 +32,37 @@
     </a>
   {% endfor %}
 </div>
+
+{% set HORIZONTAL_ALIGNMENT_VALUES = {
+ LEFT: "start",
+ CENTER: "center",
+ RIGHT: "end"
+} %}
+
+<style>
+{% scope_css %}
+  .social-links {
+    {# Alignment #}
+    {% if module.style.alignment_spacing.alignment.horizontal_align %}
+      justify-content: {{ HORIZONTAL_ALIGNMENT_VALUES[module.style.alignment_spacing.alignment.horizontal_align] }};
+    {% endif %}
+
+    {# Padding & margin #}
+    {{ module.style.alignment_spacing.spacing.css }}
+    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
+        background-color: {{ module.style.background.bg_color.color }};
+    {% endif %}
+
+    {# Background styles #}
+    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
+      background: {{ module.style.background.bg_gradient.css }};
+    {% endif %}
+    {% if module.style.background.bg_type == "bg_image" %}
+      {{ module.style.background.bg_image.css }}
+    {% endif %}
+
+    {# Border #}
+    {{ module.style.border.css }}
+  }
+{% end_scope_css%}
+</style>

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -33,36 +33,84 @@
   {% endfor %}
 </div>
 
-{% set HORIZONTAL_ALIGNMENT_VALUES = {
- LEFT: "start",
- CENTER: "center",
- RIGHT: "end"
-} %}
+{# Module styles #}
 
-<style>
-{% scope_css %}
-  .social-links {
-    {# Alignment #}
-    {% if module.style.alignment_spacing.alignment.horizontal_align %}
-      justify-content: {{ HORIZONTAL_ALIGNMENT_VALUES[module.style.alignment_spacing.alignment.horizontal_align] }};
-    {% endif %}
+{% require_css %}
+  <style>
+    {% scope_css %}
 
-    {# Padding & margin #}
-    {{ module.style.alignment_spacing.spacing.css }}
-    {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.css }};
-    {% endif %}
+        /* Social follow wrapper */
 
-    {# Background styles #}
-    {% if module.style.background.bg_type == "bg_gradient" && module.style.background.bg_gradient.css %}
-      background: {{ module.style.background.bg_gradient.css }};
-    {% endif %}
-    {% if module.style.background.bg_type == "bg_image" %}
-      {{ module.style.background.bg_image.css }}
-    {% endif %}
+        .social-links {
+          {% if module.styles.alignment.alignment.horizontal_align %}
+            {% if module.styles.alignment.alignment.horizontal_align == 'LEFT' %}
+              justify-content: flex-start;
+            {% elif module.styles.alignment.alignment.horizontal_align == 'CENTER' %}
+              justify-content: center;
+            {% elif module.styles.alignment.alignment.horizontal_align == 'RIGHT' %}
+              justify-content: flex-end;
+            {% endif %}
+          {% endif %}
+        }
 
-    {# Border #}
-    {{ module.style.border.css }}
-  }
-{% end_scope_css%}
-</style>
+        /* Social follow icons */
+
+        .social-links__link {
+          {% if module.styles.spacing.space_between_icons %}
+            margin-right: {{ module.styles.spacing.space_between_icons ~ 'px' }};
+          {% endif %}
+          {% if module.styles.spacing.spacing.margin.bottom %}
+            margin-bottom: {{ module.styles.spacing.spacing.margin.bottom.value ~ 'px' }};
+          {% endif %}
+          {% if module.styles.spacing.spacing.margin.top %}
+            margin-top: {{ module.styles.spacing.spacing.margin.top.value ~ 'px' }};
+          {% endif %}
+        }
+
+        .social-links__icon {
+          {% if module.styles.background.color.color %}
+            background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+          {% endif %}
+          {% if module.styles.corner.radius %}
+            border-radius: {{ module.styles.corner.radius ~ 'px' }};
+          {% endif %}
+          {% if module.styles.spacing.spacing.padding.bottom %}
+            padding-bottom: {{ module.styles.spacing.spacing.padding.bottom.value ~ 'px' }};
+          {% endif %}
+          {% if module.styles.spacing.spacing.padding.top %}
+            padding-top: {{ module.styles.spacing.spacing.padding.top.value ~ 'px' }};
+          {% endif %}
+          {% if module.styles.spacing.spacing.padding.left %}
+            padding-left: {{ module.styles.spacing.spacing.padding.left.value ~ 'px' }};
+          {% endif %}
+          {% if module.styles.spacing.spacing.padding.right %}
+            padding-right: {{ module.styles.spacing.spacing.padding.right.value ~ 'px' }};
+          {% endif %}
+        }
+
+        .social-links__icon svg {
+          {% if module.styles.fill.color.color %}
+            fill: {{ module.styles.fill.color.color }};
+          {% endif %}
+          {% if module.styles.size.size %}
+            height: {{ module.styles.size.size ~ 'px' }};
+            width: {{ module.styles.size.size ~ 'px' }};
+          {% endif %}
+        }
+
+        {% if module.styles.background.color.color %}
+          .social-links__icon:hover,
+          .social-links__icon:focus {
+              background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+          }
+        {% endif %}
+
+        {% if module.styles.background.color.color %}
+          .social-links__icon:active {
+            background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+          }
+        {% endif %}
+
+    {% end_scope_css %}
+  </style>
+{% end_require_css %}

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -1,22 +1,34 @@
+{# Social links #}
+
 <div class="social-links">
+
+  {# Loops through each social link in the social links repeater #}
+
   {% for item in module.social_links %}
+
+    {# Sets attributes used for the link field #}
+
     {% set href = item.social_link.url.href %}
-    {% if item.social_link.url.type is equalto "EMAIL_ADDRESS" %}
-      {% set href = "mailto:" + href %}
+    {% if item.social_link.url.type is equalto 'EMAIL_ADDRESS' %}
+      {% set href = 'mailto:' + href %}
     {% endif %}
     {% set rel = [] %}
     {% if item.social_link.no_follow %}
-      {% do rel.append("nofollow") %}
+      {% do rel.append('nofollow') %}
     {% endif %}
     {% if item.social_link.open_in_new_tab %}
-      {% do rel.append("noopener") %}
+      {% do rel.append('noopener') %}
     {% endif %}
+
+    {# Sets a custom icon if the custom option is selected #}
 
     {% if item.social_account != 'custom_icon' %}
       {% set social_icon = item.social_account %}
     {% else %}
       {% set social_icon = item.custom_icon.name %}
     {% endif %}
+
+    {# Icon #}
 
     <a class="social-links__link" href="{{ href }}"
     {% if item.social_link.open_in_new_tab %}target="_blank"{% endif %}
@@ -30,7 +42,9 @@
         unique_in_loop=True
       %}
     </a>
+
   {% endfor %}
+
 </div>
 
 {# Module styles #}

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -50,7 +50,7 @@
     {# Padding & margin #}
     {{ module.style.alignment_spacing.spacing.css }}
     {% if module.style.background.bg_type == "bg_color" && module.style.background.bg_color.color %}
-        background-color: {{ module.style.background.bg_color.color }};
+        background-color: {{ module.style.background.bg_color.css }};
     {% endif %}
 
     {# Background styles #}

--- a/src/modules/social-follow.module/module.html
+++ b/src/modules/social-follow.module/module.html
@@ -1,3 +1,83 @@
+{# Module styles #}
+
+<style>
+  {% scope_css %}
+
+      /* Social follow wrapper */
+
+      .social-links {
+        {% if module.styles.alignment.alignment.horizontal_align %}
+          {% if module.styles.alignment.alignment.horizontal_align == 'LEFT' %}
+            justify-content: flex-start;
+          {% elif module.styles.alignment.alignment.horizontal_align == 'CENTER' %}
+            justify-content: center;
+          {% elif module.styles.alignment.alignment.horizontal_align == 'RIGHT' %}
+            justify-content: flex-end;
+          {% endif %}
+        {% endif %}
+      }
+
+      /* Social follow icons */
+
+      .social-links__link {
+        {% if module.styles.spacing.space_between_icons %}
+          margin-right: {{ module.styles.spacing.space_between_icons ~ 'px' }};
+        {% endif %}
+        {% if module.styles.spacing.spacing.margin.bottom %}
+          margin-bottom: {{ module.styles.spacing.spacing.margin.bottom.value ~ 'px' }};
+        {% endif %}
+        {% if module.styles.spacing.spacing.margin.top %}
+          margin-top: {{ module.styles.spacing.spacing.margin.top.value ~ 'px' }};
+        {% endif %}
+      }
+
+      .social-links__icon {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+        {% if module.styles.corner.radius %}
+          border-radius: {{ module.styles.corner.radius ~ 'px' }};
+        {% endif %}
+        {% if module.styles.spacing.spacing.padding.bottom %}
+          padding-bottom: {{ module.styles.spacing.spacing.padding.bottom.value ~ 'px' }};
+        {% endif %}
+        {% if module.styles.spacing.spacing.padding.top %}
+          padding-top: {{ module.styles.spacing.spacing.padding.top.value ~ 'px' }};
+        {% endif %}
+        {% if module.styles.spacing.spacing.padding.left %}
+          padding-left: {{ module.styles.spacing.spacing.padding.left.value ~ 'px' }};
+        {% endif %}
+        {% if module.styles.spacing.spacing.padding.right %}
+          padding-right: {{ module.styles.spacing.spacing.padding.right.value ~ 'px' }};
+        {% endif %}
+      }
+
+      .social-links__icon svg {
+        {% if module.styles.fill.color.color %}
+          fill: {{ module.styles.fill.color.color }};
+        {% endif %}
+        {% if module.styles.size.size %}
+          height: {{ module.styles.size.size ~ 'px' }};
+          width: {{ module.styles.size.size ~ 'px' }};
+        {% endif %}
+      }
+
+      {% if module.styles.background.color.color %}
+        .social-links__icon:hover,
+        .social-links__icon:focus {
+            background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        }
+      {% endif %}
+
+      {% if module.styles.background.color.color %}
+        .social-links__icon:active {
+          background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        }
+      {% endif %}
+
+  {% end_scope_css %}
+</style>
+
 {# Social links #}
 
 <div class="social-links">
@@ -46,85 +126,3 @@
   {% endfor %}
 
 </div>
-
-{# Module styles #}
-
-{% require_css %}
-  <style>
-    {% scope_css %}
-
-        /* Social follow wrapper */
-
-        .social-links {
-          {% if module.styles.alignment.alignment.horizontal_align %}
-            {% if module.styles.alignment.alignment.horizontal_align == 'LEFT' %}
-              justify-content: flex-start;
-            {% elif module.styles.alignment.alignment.horizontal_align == 'CENTER' %}
-              justify-content: center;
-            {% elif module.styles.alignment.alignment.horizontal_align == 'RIGHT' %}
-              justify-content: flex-end;
-            {% endif %}
-          {% endif %}
-        }
-
-        /* Social follow icons */
-
-        .social-links__link {
-          {% if module.styles.spacing.space_between_icons %}
-            margin-right: {{ module.styles.spacing.space_between_icons ~ 'px' }};
-          {% endif %}
-          {% if module.styles.spacing.spacing.margin.bottom %}
-            margin-bottom: {{ module.styles.spacing.spacing.margin.bottom.value ~ 'px' }};
-          {% endif %}
-          {% if module.styles.spacing.spacing.margin.top %}
-            margin-top: {{ module.styles.spacing.spacing.margin.top.value ~ 'px' }};
-          {% endif %}
-        }
-
-        .social-links__icon {
-          {% if module.styles.background.color.color %}
-            background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-          {% endif %}
-          {% if module.styles.corner.radius %}
-            border-radius: {{ module.styles.corner.radius ~ 'px' }};
-          {% endif %}
-          {% if module.styles.spacing.spacing.padding.bottom %}
-            padding-bottom: {{ module.styles.spacing.spacing.padding.bottom.value ~ 'px' }};
-          {% endif %}
-          {% if module.styles.spacing.spacing.padding.top %}
-            padding-top: {{ module.styles.spacing.spacing.padding.top.value ~ 'px' }};
-          {% endif %}
-          {% if module.styles.spacing.spacing.padding.left %}
-            padding-left: {{ module.styles.spacing.spacing.padding.left.value ~ 'px' }};
-          {% endif %}
-          {% if module.styles.spacing.spacing.padding.right %}
-            padding-right: {{ module.styles.spacing.spacing.padding.right.value ~ 'px' }};
-          {% endif %}
-        }
-
-        .social-links__icon svg {
-          {% if module.styles.fill.color.color %}
-            fill: {{ module.styles.fill.color.color }};
-          {% endif %}
-          {% if module.styles.size.size %}
-            height: {{ module.styles.size.size ~ 'px' }};
-            width: {{ module.styles.size.size ~ 'px' }};
-          {% endif %}
-        }
-
-        {% if module.styles.background.color.color %}
-          .social-links__icon:hover,
-          .social-links__icon:focus {
-              background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-          }
-        {% endif %}
-
-        {% if module.styles.background.color.color %}
-          .social-links__icon:active {
-            background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-          }
-        {% endif %}
-
-    {% end_scope_css %}
-  </style>
-{% end_require_css %}

--- a/src/theme.json
+++ b/src/theme.json
@@ -1,5 +1,5 @@
 {
-  "label": "[STYLE FIELDS] CMS Theme Boilerplate",
+  "label": "CMS Theme Boilerplate",
   "preview_path": "./templates/home.html",
   "screenshot_path": "./images/template-previews/home.png",
   "enable_domain_stylesheets": false,

--- a/src/theme.json
+++ b/src/theme.json
@@ -1,5 +1,5 @@
 {
-  "label": "CMS Theme Boilerplate",
+  "label": "[STYLE FIELDS] CMS Theme Boilerplate",
   "preview_path": "./templates/home.html",
   "screenshot_path": "./images/template-previews/home.png",
   "enable_domain_stylesheets": false,


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [X] New feature (change which adds new functionality)

**Description**

This pull request implements the new style fields feature on the boilerplate's modules. The style fields feature allows developers to add style related fields in the "style" tab of a module. 

![styles](https://user-images.githubusercontent.com/22665237/125684482-10723cdc-460b-4172-aac1-2bad8cd16f05.png)

[Best practices](https://developers.hubspot.com/docs/cms/building-blocks/module-theme-fields/best-practices)
[Changelog](https://developers.hubspot.com/changelog/style-fields-opt-in-beta)
[Sign up to participate in the style fields beta](https://docs.google.com/forms/d/e/1FAIpQLSeOnoO9ItSWEdplUwTtrJexWaihXoZkDqLI2qcvdZ3ESFJz6A/viewform)

**Notes**

We're currently omitting adding style fields to the menu as we are aiming to do a larger rebuild in the near future that will include some accessibility improvements. 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech 
