### PR TITLE
Clean up CSS

### DIFF
--- a/src/css/components/_header.css
+++ b/src/css/components/_header.css
@@ -12,7 +12,7 @@
 }
 
 .header__row-1 {
-  padding-top: 20px;
+  padding-top: 1rem;
 }
 
 .header__row-1,
@@ -32,7 +32,7 @@
 @media (max-width: 767px) {
   .header__container {
     flex-direction: column;
-    padding: 20px 0 0;
+    padding: 1rem 0 0;
   }
 
   .header__column {
@@ -45,7 +45,7 @@
 
   .header__row-2 {
     justify-content: center;
-    padding: 30px;
+    padding: 1.05rem;
   }
 }
 
@@ -94,18 +94,18 @@
 }
 
 .header__logo .logo-company-name {
-  font-size: 28px;
-  margin-top: 7px;
+  font-size: 1.167rem;
+  margin-top: 0.7rem;
 }
 
 .header__logo--main {
-  padding-top: 20px;
+  padding-top: 1rem;
 }
 
 /* Search bar */
 
 .header__search {
-  padding: 0 22px;
+  padding: 0 1rem;
   width: auto;
 }
 
@@ -114,7 +114,7 @@
   background-position: center right 15px;
   background-repeat: no-repeat;
   height: 45px;
-  padding: 0 15px;
+  padding: 0 0.7rem;
 }
 
 .header__search .hs-search-field--open .hs-search-field__input {
@@ -140,7 +140,7 @@
 
 .header__search .hs-search-field__suggestions li a {
   color: #494A52;
-  padding: 10px 15px;
+  padding: 0.35rem 0.7rem;
   text-decoration: none;
   transition: background-color 0.3s;
 }
@@ -157,7 +157,7 @@
   }
 
   .header__search label {
-    margin: 0 20px 0 0;
+    margin: 0 1rem 0 0;
   }
 
   .header__search .hs-search-field__input {
@@ -169,7 +169,7 @@
   .header__search {
     border-top: 2px solid #CED4DB;
     order: 1;
-    padding: 30px;
+    padding: 1.05rem;
   }
 }
 
@@ -178,7 +178,7 @@
 
 .header__language-switcher {
   cursor: pointer;
-  padding-right: 35px;
+  padding-right: 1.4rem;
 }
 
 .header__language-switcher .lang_switcher_class {
@@ -225,7 +225,7 @@
 .header__language-switcher .lang_list_class li {
   border: none;
   font-size: 18px;
-  padding: 10px 15px;
+  padding: 0.35rem 0.7rem;
 }
 
 .header__language-switcher .lang_list_class li:first-child {
@@ -251,9 +251,9 @@
 .header__language-switcher--label-current {
   align-items: center;
   display: flex;
-  font-size: 18px;
-  margin-bottom: 5px;
-  margin-left: 10px;
+  font-size: 0.75rem;
+  margin-bottom: 0.175rem;
+  margin-left: 0.7rem;
 }
 
 .header__language-switcher--label-current:after {
@@ -263,15 +263,15 @@
   content: "";
   display: block;
   height: 0px;
-  margin-left: 10px;
-  margin-top: 3px;
+  margin-left: 0.7rem;
+  margin-top: 0.175rem;
   width: 0px;
 }
 
 @media (max-width: 767px) {
   .header__language-switcher {
     border-top: 2px solid #CED4DB;
-    padding-left: 30px;
+    padding-left: 1.05rem;
     padding-right: 0;
   }
 
@@ -281,14 +281,14 @@
     display: block;
     left: 30px;
     opacity: 1;
-    padding: 0 30px;
+    padding: 0 1.05rem;
     top: 0;
     visibility: visible;
   }
 
   .header__language-switcher .lang_list_class li {
     background-color: inherit;
-    font-size: 22px;
+    font-size: 0.917rem;
   }
 
   .header__language-switcher--label-current {
@@ -365,7 +365,7 @@
   .header__search--toggle:after,
   .header__language-switcher--toggle:after {
     display: none;
-    font-size: 26px;
+    font-size: 1.083rem;
     font-weight: 600;
     position: absolute;
     left: 40px;

--- a/src/css/elements/_typography.css
+++ b/src/css/elements/_typography.css
@@ -75,7 +75,7 @@ code {
 blockquote {
   border-left: 2px solid;
   margin: 0 0 1.4rem;
-  padding-left: 15px;
+  padding-left: 0.7rem;
 }
 
 /* Horizontal rules */
@@ -90,6 +90,6 @@ hr {
 /* Image alt text */
 
 img {
-  font-size: 14px;
+  font-size: 0.583rem;
   word-break: normal;
 }

--- a/src/css/objects/_containers-dnd.css
+++ b/src/css/objects/_containers-dnd.css
@@ -1,6 +1,6 @@
 .content-wrapper {
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 1rem;
 }
 
 @media screen and (min-width: 1380px) {
@@ -14,7 +14,7 @@
 }
 
 .dnd-section .dnd-column {
-  padding: 0 20px;
+  padding: 0 1rem;
 }
 
 @media (max-width: 767px) {

--- a/src/css/objects/_layout.css
+++ b/src/css/objects/_layout.css
@@ -1,388 +1,338 @@
-/* Responsive Grid */
+/* Responsive grid */
 
 .row-fluid {
-    width: 100%;
-    *zoom: 1;
+  width: 100%;
 }
 
 .row-fluid:before, .row-fluid:after {
-    display: table;
-    content: "";
+  display: table;
+  content: "";
 }
 
 .row-fluid:after {
-    clear: both;
+  clear: both;
 }
 
 .row-fluid [class*="span"] {
+  display: block;
+  float: left;
+  width: 100%;
+  min-height: 1px;
+  margin-left: 2.127659574%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.row-fluid [class*="span"]:first-child {
+  margin-left: 0;
+}
+
+.row-fluid .span12 {
+  width: 99.99999998999999%;
+}
+
+.row-fluid .span11 {
+  width: 91.489361693%;
+}
+
+.row-fluid .span10 {
+  width: 82.97872339599999%;
+}
+
+.row-fluid .span9 {
+  width: 74.468085099%;
+}
+
+.row-fluid .span8 {
+  width: 65.95744680199999%;
+}
+
+.row-fluid .span7 {
+  width: 57.446808505%;
+}
+
+.row-fluid .span6 {
+  width: 48.93617020799999%;
+}
+
+.row-fluid .span5 {
+  width: 40.425531911%;
+}
+
+.row-fluid .span4 {
+  width: 31.914893614%;
+}
+
+.row-fluid .span3 {
+  width: 23.404255317%;
+}
+
+.row-fluid .span2 {
+  width: 14.89361702%;
+}
+
+.row-fluid .span1 {
+  width: 6.382978723%;
+}
+
+.container-fluid:before, .container-fluid:after {
+  display: table;
+  content: "";
+}
+
+.container-fluid:after {
+  clear: both;
+}
+
+@media (max-width: 767px) {
+  .row-fluid {
+    width: 100%;
+  }
+
+  .row-fluid [class*="span"] {
+    display: block;
+    float: none;
+    width: auto;
+    margin-left: 0;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1139px) {
+  .row-fluid {
+    width: 100%;
+  }
+
+  .row-fluid:before, .row-fluid:after {
+    display: table;
+    content: "";
+  }
+
+  .row-fluid:after {
+    clear: both;
+  }
+
+  .row-fluid [class*="span"] {
     display: block;
     float: left;
     width: 100%;
     min-height: 1px;
-    margin-left: 2.127659574%;
-    *margin-left: 2.0744680846382977%;
+    margin-left: 2.762430939%;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     -ms-box-sizing: border-box;
     box-sizing: border-box;
-}
+  }
 
-.row-fluid [class*="span"]:first-child {
+  .row-fluid [class*="span"]:first-child {
     margin-left: 0;
-}
+  }
 
-.row-fluid .span12 {
-    width: 99.99999998999999%;
-    *width: 99.94680850063828%;
-}
+  .row-fluid .span12 {
+    width: 99.999999993%;
+  }
 
-.row-fluid .span11 {
-    width: 91.489361693%;
-    *width: 91.4361702036383%;
-}
+  .row-fluid .span11 {
+    width: 91.436464082%;
+  }
 
-.row-fluid .span10 {
-    width: 82.97872339599999%;
-    *width: 82.92553190663828%;
-}
+  .row-fluid .span10 {
+    width: 82.87292817100001%;
+  }
 
-.row-fluid .span9 {
-    width: 74.468085099%;
-    *width: 74.4148936096383%;
-}
+  .row-fluid .span9 {
+    width: 74.30939226%;
+  }
 
-.row-fluid .span8 {
-    width: 65.95744680199999%;
-    *width: 65.90425531263828%;
-}
+  .row-fluid .span8 {
+    width: 65.74585634900001%;
+  }
 
-.row-fluid .span7 {
-    width: 57.446808505%;
-    *width: 57.3936170156383%;
-}
+  .row-fluid .span7 {
+    width: 57.182320438000005%;
+  }
 
-.row-fluid .span6 {
-    width: 48.93617020799999%;
-    *width: 48.88297871863829%;
-}
+  .row-fluid .span6 {
+    width: 48.618784527%;
+  }
 
-.row-fluid .span5 {
-    width: 40.425531911%;
-    *width: 40.3723404216383%;
-}
+  .row-fluid .span5 {
+    width: 40.055248616%;
+  }
 
-.row-fluid .span4 {
-    width: 31.914893614%;
-    *width: 31.8617021246383%;
-}
+  .row-fluid .span4 {
+    width: 31.491712705%;
+  }
 
-.row-fluid .span3 {
-    width: 23.404255317%;
-    *width: 23.3510638276383%;
-}
+  .row-fluid .span3 {
+    width: 22.928176794%;
+  }
 
-.row-fluid .span2 {
-    width: 14.89361702%;
-    *width: 14.8404255306383%;
-}
+  .row-fluid .span2 {
+    width: 14.364640883%;
+  }
 
-.row-fluid .span1 {
-    width: 6.382978723%;
-    *width: 6.329787233638298%;
-}
-
-.container-fluid {
-    *zoom: 1;
-}
-
-.container-fluid:before, .container-fluid:after {
-    display: table;
-    content: "";
-}
-
-.container-fluid:after {
-    clear: both;
-}
-
-@media (max-width: 767px) {
-    .row-fluid {
-        width: 100%;
-    }
-
-    .row-fluid [class*="span"] {
-        display: block;
-        float: none;
-        width: auto;
-        margin-left: 0;
-    }
-}
-
-@media (min-width: 768px) and (max-width: 1139px) {
-    .row-fluid {
-        width: 100%;
-        *zoom: 1;
-    }
-
-    .row-fluid:before, .row-fluid:after {
-        display: table;
-        content: "";
-    }
-
-    .row-fluid:after {
-        clear: both;
-    }
-
-    .row-fluid [class*="span"] {
-        display: block;
-        float: left;
-        width: 100%;
-        min-height: 1px;
-        margin-left: 2.762430939%;
-        *margin-left: 2.709239449638298%;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        -ms-box-sizing: border-box;
-        box-sizing: border-box;
-    }
-
-    .row-fluid [class*="span"]:first-child {
-        margin-left: 0;
-    }
-
-    .row-fluid .span12 {
-        width: 99.999999993%;
-        *width: 99.9468085036383%;
-    }
-
-    .row-fluid .span11 {
-        width: 91.436464082%;
-        *width: 91.38327259263829%;
-    }
-
-    .row-fluid .span10 {
-        width: 82.87292817100001%;
-        *width: 82.8197366816383%;
-    }
-
-    .row-fluid .span9 {
-        width: 74.30939226%;
-        *width: 74.25620077063829%;
-    }
-
-    .row-fluid .span8 {
-        width: 65.74585634900001%;
-        *width: 65.6926648596383%;
-    }
-
-    .row-fluid .span7 {
-        width: 57.182320438000005%;
-        *width: 57.129128948638304%;
-    }
-
-    .row-fluid .span6 {
-        width: 48.618784527%;
-        *width: 48.5655930376383%;
-    }
-
-    .row-fluid .span5 {
-        width: 40.055248616%;
-        *width: 40.0020571266383%;
-    }
-
-    .row-fluid .span4 {
-        width: 31.491712705%;
-        *width: 31.4385212156383%;
-    }
-
-    .row-fluid .span3 {
-        width: 22.928176794%;
-        *width: 22.874985304638297%;
-    }
-
-    .row-fluid .span2 {
-        width: 14.364640883%;
-        *width: 14.311449393638298%;
-    }
-
-    .row-fluid .span1 {
-        width: 5.801104972%;
-        *width: 5.747913482638298%;
-    }
+  .row-fluid .span1 {
+    width: 5.801104972%;
+  }
 }
 
 @media (min-width: 1280px) {
-    .row-fluid {
-        width: 100%;
-        *zoom: 1;
-    }
+  .row-fluid {
+    width: 100%;
+  }
 
-    .row-fluid:before, .row-fluid:after {
-        display: table;
-        content: "";
-    }
+  .row-fluid:before, .row-fluid:after {
+    display: table;
+    content: "";
+  }
 
-    .row-fluid:after {
-        clear: both;
-    }
+  .row-fluid:after {
+    clear: both;
+  }
 
-    .row-fluid [class*="span"] {
-        display: block;
-        float: left;
-        width: 100%;
-        min-height: 1px;
-        margin-left: 2.564102564%;
-        *margin-left: 2.510911074638298%;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        -ms-box-sizing: border-box;
-        box-sizing: border-box;
-    }
+  .row-fluid [class*="span"] {
+    display: block;
+    float: left;
+    width: 100%;
+    min-height: 1px;
+    margin-left: 2.564102564%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -ms-box-sizing: border-box;
+    box-sizing: border-box;
+  }
 
-    .row-fluid [class*="span"]:first-child {
-        margin-left: 0;
-    }
+  .row-fluid [class*="span"]:first-child {
+    margin-left: 0;
+  }
 
-    .row-fluid .span12 {
-        width: 100%;
-        *width: 99.94680851063829%;
-    }
+  .row-fluid .span12 {
+    width: 100%;
+  }
 
-    .row-fluid .span11 {
-        width: 91.45299145300001%;
-        *width: 91.3997999636383%;
-    }
+  .row-fluid .span11 {
+    width: 91.45299145300001%;
+  }
 
-    .row-fluid .span10 {
-        width: 82.905982906%;
-        *width: 82.8527914166383%;
-    }
+  .row-fluid .span10 {
+    width: 82.905982906%;
+  }
 
-    .row-fluid .span9 {
-        width: 74.358974359%;
-        *width: 74.30578286963829%;
-    }
+  .row-fluid .span9 {
+    width: 74.358974359%;
+  }
 
-    .row-fluid .span8 {
-        width: 65.81196581200001%;
-        *width: 65.7587743226383%;
-    }
+  .row-fluid .span8 {
+    width: 65.81196581200001%;
+  }
 
-    .row-fluid .span7 {
-        width: 57.264957265%;
-        *width: 57.2117657756383%;
-    }
+  .row-fluid .span7 {
+    width: 57.264957265%;
+  }
 
-    .row-fluid .span6 {
-        width: 48.717948718%;
-        *width: 48.6647572286383%;
-    }
+  .row-fluid .span6 {
+    width: 48.717948718%;
+  }
 
-    .row-fluid .span5 {
-        width: 40.170940171000005%;
-        *width: 40.117748681638304%;
-    }
+  .row-fluid .span5 {
+    width: 40.170940171000005%;
+  }
 
-    .row-fluid .span4 {
-        width: 31.623931624%;
-        *width: 31.5707401346383%;
-    }
+  .row-fluid .span4 {
+    width: 31.623931624%;
+  }
 
-    .row-fluid .span3 {
-        width: 23.076923077%;
-        *width: 23.0237315876383%;
-    }
+  .row-fluid .span3 {
+    width: 23.076923077%;
+  }
 
-    .row-fluid .span2 {
-        width: 14.529914530000001%;
-        *width: 14.4767230406383%;
-    }
+  .row-fluid .span2 {
+    width: 14.529914530000001%;
+  }
 
-    .row-fluid .span1 {
-        width: 5.982905983%;
-        *width: 5.929714493638298%;
-    }
+  .row-fluid .span1 {
+    width: 5.982905983%;
+  }
 }
 
 /* Clearfix */
 
-.clearfix {
-    *zoom: 1;
-}
-
 .clearfix:before, .clearfix:after {
-    display: table;
-    content: "";
+  display: table;
+  content: "";
 }
 
 .clearfix:after {
-    clear: both;
+  clear: both;
 }
 
-/* Visibilty Classes */
+/* Visibilty classes */
 
 .hide {
-    display: none;
+  display: none;
 }
 
 .show {
-    display: block;
+  display: block;
 }
 
 .invisible {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 .hidden {
-    display: none;
-    visibility: hidden;
+  display: none;
+  visibility: hidden;
 }
 
-/* Responsive Visibilty Classes */
+/* Responsive visibilty classes */
 
 .visible-phone {
-    display: none !important;
+  display: none !important;
 }
 
 .visible-tablet {
-    display: none !important;
+  display: none !important;
 }
 
 .hidden-desktop {
-    display: none !important;
+  display: none !important;
 }
 
 @media (max-width: 767px) {
-    .visible-phone {
-        display: inherit !important;
-    }
+  .visible-phone {
+    display: inherit !important;
+  }
 
-    .hidden-phone {
-        display: none !important;
-    }
+  .hidden-phone {
+    display: none !important;
+  }
 
-    .hidden-desktop {
-        display: inherit !important;
-    }
+  .hidden-desktop {
+    display: inherit !important;
+  }
 
-    .visible-desktop {
-        display: none !important;
-    }
+  .visible-desktop {
+    display: none !important;
+  }
 }
 
 @media (min-width: 768px) and (max-width: 1139px) {
-    .visible-tablet {
-        display: inherit !important;
-    }
+  .visible-tablet {
+    display: inherit !important;
+  }
 
-    .hidden-tablet {
-        display: none !important;
-    }
+  .hidden-tablet {
+    display: none !important;
+  }
 
-    .hidden-desktop {
-        display: inherit !important;
-    }
+  .hidden-desktop {
+    display: inherit !important;
+  }
 
-    .visible-desktop {
-        display: none !important ;
-    }
+  .visible-desktop {
+    display: none !important;
+  }
 }

--- a/src/css/objects/_layout.css
+++ b/src/css/objects/_layout.css
@@ -6,14 +6,14 @@
 
 .row-fluid:before, .row-fluid:after {
   display: table;
-  content: "";
+  content: '';
 }
 
 .row-fluid:after {
   clear: both;
 }
 
-.row-fluid [class*="span"] {
+.row-fluid [class*='span'] {
   display: block;
   float: left;
   width: 100%;
@@ -25,7 +25,7 @@
   box-sizing: border-box;
 }
 
-.row-fluid [class*="span"]:first-child {
+.row-fluid [class*='span']:first-child {
   margin-left: 0;
 }
 
@@ -79,7 +79,7 @@
 
 .container-fluid:before, .container-fluid:after {
   display: table;
-  content: "";
+  content: '';
 }
 
 .container-fluid:after {
@@ -91,7 +91,7 @@
     width: 100%;
   }
 
-  .row-fluid [class*="span"] {
+  .row-fluid [class*='span'] {
     display: block;
     float: none;
     width: auto;
@@ -106,14 +106,14 @@
 
   .row-fluid:before, .row-fluid:after {
     display: table;
-    content: "";
+    content: '';
   }
 
   .row-fluid:after {
     clear: both;
   }
 
-  .row-fluid [class*="span"] {
+  .row-fluid [class*='span'] {
     display: block;
     float: left;
     width: 100%;
@@ -125,7 +125,7 @@
     box-sizing: border-box;
   }
 
-  .row-fluid [class*="span"]:first-child {
+  .row-fluid [class*='span']:first-child {
     margin-left: 0;
   }
 
@@ -185,14 +185,14 @@
 
   .row-fluid:before, .row-fluid:after {
     display: table;
-    content: "";
+    content: '';
   }
 
   .row-fluid:after {
     clear: both;
   }
 
-  .row-fluid [class*="span"] {
+  .row-fluid [class*='span'] {
     display: block;
     float: left;
     width: 100%;
@@ -204,7 +204,7 @@
     box-sizing: border-box;
   }
 
-  .row-fluid [class*="span"]:first-child {
+  .row-fluid [class*='span']:first-child {
     margin-left: 0;
   }
 
@@ -261,7 +261,7 @@
 
 .clearfix:before, .clearfix:after {
   display: table;
-  content: "";
+  content: '';
 }
 
 .clearfix:after {

--- a/src/css/templates/blog.css
+++ b/src/css/templates/blog.css
@@ -160,7 +160,7 @@
 
 .blog-post__tags svg {
   height: auto;
-  margin-right: 10px;
+  margin-right: 0.35rem;
   width: 15px;
 }
 

--- a/src/css/templates/system.css
+++ b/src/css/templates/system.css
@@ -59,15 +59,13 @@
 }
 
 .systems-page form input[type='submit'] {
-  margin: 0.625rem 0;
+  margin: 0.7rem 0;
   display: block;
 }
 
 /* Search pages */
 
 .hs-search-results__title {
-  color: #494A52;
-  font-family: Merriweather, serif;
   font-size: 1.25rem;
   margin-bottom: 0.35rem;
   text-decoration: underline;
@@ -91,12 +89,12 @@
 .systems-page #hs-login-widget-remember,
 .systems-page #hs-login-widget-remember ~ label {
   display: inline-block;
-  margin-bottom: 3px;
+  margin-bottom: 0.175rem;
 }
 
 .systems-page #hs_login_reset {
   display: block;
-  margin-bottom: 0.625rem;
+  margin-bottom: 0.7rem;
 }
 
 /* Backup unsubscribe */
@@ -123,6 +121,7 @@
 }
 
 /* Membership pages */
+
 #hs-membership-form a[class*='show-password'] {
   font-size: 0.75rem;
 }

--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -31,7 +31,7 @@
 /* 1a. Containers */
 
 {% set container_width = theme.spacing.max_width ~ 'px' %}
-{% set dnd_section_padding = theme.spacing.vertical_spacing ~ 'px ' ~ '20px' %}
+{% set dnd_section_padding = theme.spacing.vertical_spacing ~ 'px ' ~ '1rem' %}
 
 /* 1b. Colors */
 
@@ -556,14 +556,38 @@ tfoot td {
 {##########################   10. System pages   ###########################}
 {###########################################################################}
 
-
+.hs-search-results__title {
+  {{ heading_one.style }};
+  color: {{ heading_one.color }};
+}
 
 {###########################################################################}
 {############################   11. Modules   ##############################}
 {###########################################################################}
 
+/* Pricing card */
+
 .card__price {
   {{ heading_three.style }};
   color: {{ heading_three.color }};
   font-size: {{ heading_three.size ~ heading_three.size_unit }};
+}
+
+.card__body svg {
+  fill: {{ primary_color }};
+}
+
+/* Social follow */
+
+.social-links__icon {
+  background-color: {{ primary_color }};
+}
+
+.social-links__icon:hover,
+.social-links__icon:focus {
+  background-color: {{ color_variant(primary_color, -40) }};
+}
+
+.social-links__icon:active {
+  background-color: {{ color_variant(primary_color, 40) }};
 }

--- a/src/modules/card.module/module.css
+++ b/src/modules/card.module/module.css
@@ -18,10 +18,10 @@
   height: auto;
   margin: 0 auto;
   max-width: 100%;
-  padding: 0.7rem 10px;
+  padding: 0.7rem;
 }
 
 .card__text {
-  padding: 0 10px;
+  padding: 0 0.7rem;
   width: 100%;
 }

--- a/src/modules/menu.module/module.css
+++ b/src/modules/menu.module/module.css
@@ -27,8 +27,8 @@
 .menu__link {
   color: #494A52;
   font-family: Lato, sans-serif;
-  font-size: 22px;
-  line-height: 40px;
+  font-size: 0.917rem;
+  line-height: 1.667rem;
   text-decoration: none;
 }
 
@@ -45,7 +45,7 @@
 
 @media (min-width: 768px) and (max-width: 1150px) {
   .menu__link {
-    font-size: 20px;
+    font-size: 0.833rem;
   }
 }
 
@@ -57,7 +57,7 @@
 
   .menu__link {
     display: block;
-    font-size: 26px;
+    font-size: 1.083rem;
   }
 }
 
@@ -65,7 +65,7 @@
 
 .menu__item--depth-1 {
   display: inline-block;
-  padding: 15px 20px;
+  padding: 0.7rem 0.875rem;
   text-transform: uppercase;
 }
 
@@ -86,7 +86,7 @@
   }
 
   .menu__item--depth-1 > .menu__link {
-    padding: 7px 30px;
+    padding: 0.35rem 1.225rem;
   }
 
   .menu__item--depth-1 > .menu__link--active-link:after {
@@ -135,7 +135,7 @@
 .menu__submenu .menu__link {
   background-color: #FFF;
   display: block;
-  padding: 10px 30px;
+  padding: 0.7rem 1.05rem;
   transition: background-color 0.3s;
   width: 100%;
 }
@@ -156,7 +156,7 @@
 /* Accounts for child toggle */
 
 .menu__submenu .menu__item--has-submenu > .menu__link {
-  padding-right: 70px;
+  padding-right: 3rem;
 }
 
 /* Creates the triangle at the top of the submenu drop down */
@@ -167,11 +167,11 @@
     border: 2px solid #494A52;
     border-radius: 6px;
     box-shadow: 0 2px 9px 0 rgb(0 0 0 / 20%);
-    content: "";
+    content: '';
     display: block;
     height: 30px;
     left: 125px;
-    margin-left: 20px;
+    margin-left: 1rem;
     overflow: hidden;
     position: absolute;
     top: -12px;
@@ -212,7 +212,7 @@
 
   .menu__submenu .menu__link {
     display: block;
-    padding: 7px 60px;
+    padding: 0.7rem 2rem;
     transition: none;
     width: 100%;
   }
@@ -228,7 +228,7 @@
   }
 
   .menu__submenu--level-3 .menu__item .menu__link {
-    padding: 7px 90px;
+    padding: 0.7rem 3rem;
   }
 }
 
@@ -237,7 +237,7 @@
 @media(min-width: 768px) {
   .menu__submenu .menu__child-toggle {
     margin-left: auto;
-    padding: 0 30px;
+    padding: 0 1.05rem;
   }
 
   .menu__child-toggle {
@@ -287,7 +287,7 @@
     display: block;
     height: 20px;
     margin-left: auto;
-    margin-right: 30px;
+    margin-right: 1.05rem;
     transition: transform 0.4s;
     width: 20px;
   }

--- a/src/modules/pricing-card.module/module.css
+++ b/src/modules/pricing-card.module/module.css
@@ -3,25 +3,24 @@
 }
 .card--pricing {
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.15);
-  padding: 2rem;
+  padding: 2.1rem;
 }
 
 @media screen and (max-width: 1200px) {
   .card--pricing {
-    padding: 2rem 1rem;
+    padding: 2.1rem 0.7rem;
   }
 }
 
 @media screen and (max-width: 787px) {
   .card--pricing {
-    margin-bottom: 1rem;
+    margin-bottom: 1.4rem;
   }
 }
 
 .card__subtitle,
 .card__body li {
   font-size: 0.9rem;
-  line-height: 1.2em;
 }
 
 .card__body ul,
@@ -32,19 +31,13 @@
 .card__body li {
   list-style: none;
   margin: 0;
-  padding: 0.25rem 0;
+  padding: 0.35rem 0;
   text-align: left;
 }
 
 .card__body svg {
   display: inline-block;
-  fill: #494a52;
-  margin-right: 10px;
+  margin-right: 0.7rem;
   max-width: 20px;
-}
-
-.card__button {
-  background-color: #494a52;
-  color: #fff;
 }
 

--- a/src/modules/social-follow.module/module.css
+++ b/src/modules/social-follow.module/module.css
@@ -6,27 +6,17 @@
 }
 
 .social-links__icon {
-  background-color: #494A52;
   border-radius: 50%;
   display: inline-flex;
-  height: 40px;
-  margin: 0 5px;
+  height: 1.75rem;
+  margin: 0 0.35rem;
   position: relative;
-  width: 40px;
-}
-
-.social-links__icon:hover,
-.social-links__icon:focus {
-  background-color: #21222A;
-}
-
-.social-links__icon:active {
-  background-color: #71727A;
+  width: 1.75rem;
 }
 
 .social-links__icon svg {
   fill: #FFF;
-  height: 15px;
+  height: 0.625rem;
   left: 50%;
   position: absolute;
   top: 50%;


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Cleaning up some parts of the CSS including: 
- Removing *css-property workaround in layout.css that was designed to support IE 7 and older. 
- Making all comments sentence case
- Swapping px for rem where it made sense (generally kept pixels in cases like top, left, bottom, right / height and width in some cases / border and border radius. I swapped px for rem in cases of font size and spacing. Open to going another way if people have strong opinions on this. I mainly wanted to try to get to a somewhat more consistent place with this. 

**Relevant links**

Fixes #309 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech
