### PR TITLE
Add system template titles

### DIFF
--- a/src/templates/layouts/base.html
+++ b/src/templates/layouts/base.html
@@ -5,7 +5,7 @@
 <html lang="{{ html_lang }}" {{ html_lang_dir }}>
   <head>
     <meta charset="utf-8">
-    {% if page_meta.html_title or pageTitle %}<title>{{ page_meta.html_title || pageTitle }}</title>{% endif %}
+    {% if page_meta.html_title || pageTitle %}<title>{{ page_meta.html_title || pageTitle }}</title>{% endif %}
     {% if site_settings.favicon_src %}<link rel="shortcut icon" href="{{ site_settings.favicon_src }}" />{% endif %}
     <meta name="description" content="{{ page_meta.meta_description }}">
     {{ require_css(get_asset_url("../../css/main.css")) }}

--- a/src/templates/layouts/base.html
+++ b/src/templates/layouts/base.html
@@ -5,7 +5,7 @@
 <html lang="{{ html_lang }}" {{ html_lang_dir }}>
   <head>
     <meta charset="utf-8">
-    {% if page_meta.html_title %}<title>{{ page_meta.html_title }}</title>{% endif %}
+    {% if page_meta.html_title or pageTitle %}<title>{{ page_meta.html_title || pageTitle }}</title>{% endif %}
     {% if site_settings.favicon_src %}<link rel="shortcut icon" href="{{ site_settings.favicon_src }}" />{% endif %}
     <meta name="description" content="{{ page_meta.meta_description }}">
     {{ require_css(get_asset_url("../../css/main.css")) }}

--- a/src/templates/system/404.html
+++ b/src/templates/system/404.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Error 404 | Page not found" %}
 
 {% block body %}

--- a/src/templates/system/404.html
+++ b/src/templates/system/404.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Error 404 | Page not found" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}

--- a/src/templates/system/500.html
+++ b/src/templates/system/500.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Error 500 | Server error" %}
 
 {% block body %}

--- a/src/templates/system/500.html
+++ b/src/templates/system/500.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Error 500 | Server error" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}

--- a/src/templates/system/backup-unsubscribe.html
+++ b/src/templates/system/backup-unsubscribe.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Unsubscribe" %}
 
 {% block body %}

--- a/src/templates/system/backup-unsubscribe.html
+++ b/src/templates/system/backup-unsubscribe.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Unsubscribe" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}

--- a/src/templates/system/membership-login.html
+++ b/src/templates/system/membership-login.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Membership | Login" %}
 
 {% block header %}
 {% endblock %}

--- a/src/templates/system/membership-login.html
+++ b/src/templates/system/membership-login.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Membership | Login" %}
 
 {% block header %}

--- a/src/templates/system/membership-register.html
+++ b/src/templates/system/membership-register.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Membership | Register" %}
 
 {% block header %}

--- a/src/templates/system/membership-register.html
+++ b/src/templates/system/membership-register.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Membership | Register" %}
 
 {% block header %}
 {% endblock %}

--- a/src/templates/system/membership-reset-password-request.html
+++ b/src/templates/system/membership-reset-password-request.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Membership | Reset password request" %}
 
 {% block header %}
 {% endblock %}

--- a/src/templates/system/membership-reset-password-request.html
+++ b/src/templates/system/membership-reset-password-request.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Membership | Reset password request" %}
 
 {% block header %}

--- a/src/templates/system/membership-reset-password.html
+++ b/src/templates/system/membership-reset-password.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Membership | Reset password" %}
 
 {% block header %}
 {% endblock %}

--- a/src/templates/system/membership-reset-password.html
+++ b/src/templates/system/membership-reset-password.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Membership | Reset password" %}
 
 {% block header %}

--- a/src/templates/system/password-prompt.html
+++ b/src/templates/system/password-prompt.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "This page is private | Enter password" %}
 
 {% block body %}

--- a/src/templates/system/password-prompt.html
+++ b/src/templates/system/password-prompt.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "This page is private | Enter password" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}

--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Search results" %}
 
 {% block body %}

--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Search results" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}

--- a/src/templates/system/subscription-preferences.html
+++ b/src/templates/system/subscription-preferences.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Subscription preferences" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}

--- a/src/templates/system/subscription-preferences.html
+++ b/src/templates/system/subscription-preferences.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Subscription preferences" %}
 
 {% block body %}

--- a/src/templates/system/subscriptions-confirmation.html
+++ b/src/templates/system/subscriptions-confirmation.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{# pageTitle is used on system templates for setting a value for the title tag #}
 {% set pageTitle = "Confirm subscriptions" %}
 
 {% block body %}

--- a/src/templates/system/subscriptions-confirmation.html
+++ b/src/templates/system/subscriptions-confirmation.html
@@ -6,6 +6,7 @@
 -->
 {% set template_css = '../../css/templates/system.css' %}
 {% extends '../layouts/base.html' %}
+{% set pageTitle = "Confirm subscriptions" %}
 
 {% block body %}
 {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}


### PR DESCRIPTION
**Types of change**

- [x] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

It was reported that our system templates do not support page titles. This PR adds custom page titles to system templates by setting a variable in each template, and conditionally using the variable if `page_meta.html_title` isn't present.

@TheWebTech @ajlaporte I took an initial pass at the titles for each template, but am highly open to any feedback/ recommendations.

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.

