### PR TITLE
Add CTA functionality to button

### DIFF
--- a/src/modules/button.module/fields.json
+++ b/src/modules/button.module/fields.json
@@ -1,9 +1,45 @@
 [
   {
+    "label": "Button type",
+    "name": "button_type",
+    "type": "choice",
+    "display": "radio",
+    "inline_help_text": "",
+    "help_text": "",
+    "required": false,
+    "locked": false,
+    "choices": [
+      [
+        "button",
+        "Button"
+      ],
+      [
+        "cta",
+        "CTA"
+      ]
+    ],
+    "placeholder": "",
+    "default": "button"
+  },
+  {
+    "label": "CTA",
+    "name": "cta_guid",
+    "type": "cta",
+    "sortable": false,
+    "required": false,
+    "locked": false,
+    "default": null,
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_value_regex": "cta",
+      "operator": "EQUAL"
+    }
+  },
+  {
     "label": "Button link",
     "name": "link",
     "type": "link",
-    "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
+    "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS", "BLOG"],
     "default": {
       "url": {
         "href": "",
@@ -11,6 +47,11 @@
       },
       "no_follow": false,
       "open_in_new_tab": false
+    },
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_value_regex": "button",
+      "operator": "EQUAL"
     }
   },
   {
@@ -18,7 +59,12 @@
     "name": "button_text",
     "type": "text",
     "required": true,
-    "default": "Add a button link here"
+    "default": "Add button text here",
+    "visibility": {
+      "controlling_field": "button_type",
+      "controlling_value_regex": "button",
+      "operator": "EQUAL"
+    }
   },
   {
     "label": "Styles",
@@ -36,7 +82,12 @@
             "name": "font",
             "type": "font"
           }
-        ]
+        ],
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_value_regex": "button",
+          "operator": "EQUAL"
+        }
       },
       {
         "label": "Background",
@@ -48,7 +99,12 @@
             "name": "color",
             "type": "color"
           }
-        ]
+        ],
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_value_regex": "button",
+          "operator": "EQUAL"
+        }
       },
       {
         "label": "Border",
@@ -60,7 +116,12 @@
             "name" : "border",
             "type" : "border"
           }
-        ]
+        ],
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_value_regex": "button",
+          "operator": "EQUAL"
+        }
       },
       {
         "label": "Corner",
@@ -76,7 +137,12 @@
             "step": 1,
             "suffix": "px"
           }
-        ]
+        ],
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_value_regex": "button",
+          "operator": "EQUAL"
+        }
       },
       {
         "label": "Spacing",
@@ -88,7 +154,12 @@
             "name": "spacing",
             "type": "spacing"
           }
-        ]
+        ],
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_value_regex": "button",
+          "operator": "EQUAL"
+        }
       },
       {
         "label": "Alignment",
@@ -101,7 +172,12 @@
             "type": "alignment",
             "alignment_direction": "HORIZONTAL"
           }
-        ]
+        ],
+        "visibility": {
+          "controlling_field": "button_type",
+          "controlling_value_regex": "button",
+          "operator": "EQUAL"
+        }
       }
     ]
   }

--- a/src/modules/button.module/fields.json
+++ b/src/modules/button.module/fields.json
@@ -162,6 +162,54 @@
         }
       },
       {
+        "label": "Hover",
+        "name": "hover",
+        "type": "group",
+        "children": [
+          {
+            "label": "Text",
+            "name": "text",
+            "type": "group",
+            "children": [
+              {
+                "label": "Font",
+                "name": "font",
+                "type": "font",
+                "visibility": {
+                  "hidden_subfields": {
+                    "size": true
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "label": "Background",
+            "name": "background",
+            "type": "group",
+            "children": [
+              {
+                "label": "Color",
+                "name": "color",
+                "type": "color"
+              }
+            ]
+          },
+          {
+            "label": "Border",
+            "name": "border",
+            "type": "group",
+            "children": [
+              {
+                "label" : "Border",
+                "name" : "border",
+                "type" : "border"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "label": "Alignment",
         "name": "alignment",
         "type": "group",

--- a/src/modules/button.module/module.html
+++ b/src/modules/button.module/module.html
@@ -72,8 +72,6 @@
   </style>
 
   {# Sets attributes used for the link field #}
-
-  {# Sets attributes used for the link field #}
   {% macro link_attributes() %}
     {% set link_attributes = {} %}
     

--- a/src/modules/button.module/module.html
+++ b/src/modules/button.module/module.html
@@ -76,7 +76,9 @@
   {% endmacro %}
 
   {# Setting the link's target attribute to blank if the 'open in new tab' field is toggled #}
-  {% if module.link.open_in_new_tab %}{% set target = 'target="_blank"'%}{% endif %}
+  {% if module.link.open_in_new_tab %}
+    {% set target = 'target="_blank"'%}
+  {% endif %}
 
   {# Checking to see if either field is toggled 'true' #}
   {% if module.link.open_in_new_tab || module.link.no_follow %}

--- a/src/modules/button.module/module.html
+++ b/src/modules/button.module/module.html
@@ -72,35 +72,29 @@
   </style>
 
   {# Sets attributes used for the link field #}
-  {% macro link_attributes() %}
-    {% set link_attributes = {} %}
+  {% macro setLinkAttributes()%}
     
-    {# Setting href #}
-    {% if module.button_link.url.href != '' %}
-      {# If the URL type is set to email, append `mailto:` in front of the inputted value #}
-      {% if module.button_link.url.type is equalto 'EMAIL_ADDRESS' %}
-        {% set href = link_attributes.update({'href': 'mailto:' ~ module.button_link.url.href}) %}
-      {% else %}
-        {% set href = link_attributes.update({'href': module.button_link.url.href}) %}
-      {% endif %}
+    {# Setting href - If the URL type is set to email, append `mailto:` in front of the inputted value #}
+    {% set href = (module.button_link.url.type is equalto 'EMAIL_ADDRESS') ? 'mailto:' ~ module.button_link.url.href : module.button_link.url.href %}
+    {% if href %}
+      {{ {'href': '{{ href }}'}|xmlattr }}
     {% endif %}
-
+  
     {# Setting the link's target and rel attributes based on the 'open in new tab' and 'tell search engines not to follow this link' fields being toggled #}
-    {% if module.button_link.no_follow && module.button_link.open_in_new_tab %}  
-      {% set rel = link_attributes.update({'rel': 'noopener nofollow', 'target': '_blank'})%}
-    {% elif module.button_link.no_follow %}
-        {% set rel = link_attributes.update({'rel': 'nofollow'})%}
+    {% if module.button_link.open_in_new_tab and module.button_link.no_follow %}
+      {{ {'rel': 'noopener nofollow', 'target': '_blank'}|xmlattr }}
     {% elif module.button_link.open_in_new_tab %}
-      {% set rel = link_attributes.update({'rel': 'noopener', 'target': '_blank'})%}
-    {% endif %}
-
-    {{ link_attributes|xmlattr }}
+      {{ {'rel': 'noopener', 'target': '_blank'}|xmlattr }}
+    {% elif module.button_link.no_follow %}
+      {{ {'rel': 'nofollow'}|xmlattr }}
+    {% endif %} 
+  
   {% endmacro %}
 
   {# Button #}
 
   <div class="button-wrapper">
-    <a class="button" {{ link_attributes() }}>{{ module.button_text }}</a>
+    <a class="button" {{ setLinkAttributes() }}>{{ module.button_text }}</a>
   </div>
 
 {% endif %}

--- a/src/modules/button.module/module.html
+++ b/src/modules/button.module/module.html
@@ -1,67 +1,93 @@
-{# Module styles #}
+{# Checking if CTA or Button type #}
+{% if module.button_type == "cta" %}
 
-<style>
-  {% scope_css %}
+  {% cta guid='{{ module.cta_guid }}' %}
+    
+{% else %}
 
-    {# Button wrapper #}
+  {# Button styles #}
 
-    {% if module.styles.alignment.alignment %}
-      .button-wrapper {
-        text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+  <style>
+    {% scope_css %}
+
+      {# Button wrapper #}
+
+      {% if module.styles.alignment.alignment %}
+        .button-wrapper {
+          text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+        }
+      {% endif %}
+
+      {# Button #}
+
+      .button {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+        {{ module.styles.border.border.css }}
+        {% if module.styles.corner.radius %}
+          border-radius: {{ module.styles.corner.radius ~ 'px' }};
+        {% endif %}
+        {{ module.styles.text.font.css }}
+        {{ module.styles.spacing.spacing.css }}
       }
+
+      .button:hover,
+      .button:focus {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+      }
+
+      .button:active {
+        {% if module.styles.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% endif %}
+      }
+
+    {% end_scope_css %}
+  </style>
+
+  {# Sets attributes used for the link field #}
+
+  {% macro href() %}
+    {% if module.link.url.href != "" %}
+      {# If the URL type is set to email, append `mailto:` in front of the inputted value #}
+      {% if module.link.url.type is equalto "EMAIL_ADDRESS" %}
+        {{ { 'href': 'mailto:' ~ module.link.url.href }|xmlattr }}
+      {% else %}
+        {# Rule check:
+          Unless the URL entered has http:// or  https:// at the front,
+          is a telephone number (sniffed out by the value containing `tel:),
+          or the URL field doesn't have a value (because one of the other link types was chosen),
+          set the href variable to be `//` and append the entered URL string.
+          Otherwise, set the href to the exact value (unless its false or undefined then set it to be empty) 
+        #}
+        {% unless (module.link.url.href is string_containing "//")
+          or (!module.link is string_startingwith "tel:")
+          or !module.link.url.href
+        %}
+          {{ { 'href': '//' ~ module.link.url.href }|xmlattr }}
+        {% else %}
+          {{ { 'href': module.link.url.href || "" }|xmlattr }}
+        {% endunless %}
+      {% endif %}
     {% endif %}
+  {% endmacro %}
 
-    {# Button #}
+  {# Setting the link's target attribute to blank if the 'open in new tab' field is toggled #}
+  {% if module.link.open_in_new_tab %}{% set target = 'target="_blank"'%}{% endif %}
 
-    .button {
-      {% if module.styles.background.color.color %}
-        background-color: rgba({{ module.styles.background.color.color|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-      {% endif %}
-      {{ module.styles.border.border.css }}
-      {% if module.styles.corner.radius %}
-        border-radius: {{ module.styles.corner.radius ~ 'px' }};
-      {% endif %}
-      {{ module.styles.text.font.css }}
-      {{ module.styles.spacing.spacing.css }}
-    }
+  {# Checking to see if either field is toggled 'true' #}
+  {% if module.link.open_in_new_tab || module.link.no_follow %}
+    {# Setting the link's rel attribute to noopener if the 'open in new tab' field is toggled. Also setting it to nofollow if the 'tell search engines not to follow this link' field is toggled #}
+    {% set rel = 'rel="' ~ (module.link.open_in_new_tab ? "noopener " : null) ~ (module.link.no_follow ? "nofollow" : null) ~ '"' %}
+  {% endif %}
 
-    .button:hover,
-    .button:focus {
-      {% if module.styles.background.color.color %}
-        background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-      {% endif %}
-    }
+  {# Button #}
 
-    .button:active {
-      {% if module.styles.background.color.color %}
-        background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
-      {% endif %}
-    }
+  <div class="button-wrapper">
+    <a class="button" {{ href() }} {{ target }} {{ rel }}>{{ module.button_text }}</a>
+  </div>
 
-  {% end_scope_css %}
-</style>
-
-{# Sets attributes used for the link field #}
-
-{% set href = module.link.url.href %}
-{% if module.link.url.type is equalto 'EMAIL_ADDRESS' %}
-  {% set href = 'mailto:' + href %}
 {% endif %}
-{% set rel = [] %}
-{% if module.link.no_follow %}
-  {% do rel.append('nofollow') %}
-{% endif %}
-{% if module.link.open_in_new_tab %}
-  {% do rel.append('noopener') %}
-{% endif %}
-
-{# Button #}
-
-<div class="button-wrapper">
-  <a class="button" href="{{ href }}"
-  {% if module.link.open_in_new_tab %}target="_blank"{% endif %}
-  {% if rel %}rel="{{ rel|join(' ') }}"{% endif %}
-  >
-    {{ module.button_text }}
-  </a>
-</div>

--- a/src/modules/button.module/module.html
+++ b/src/modules/button.module/module.html
@@ -73,46 +73,36 @@
 
   {# Sets attributes used for the link field #}
 
-  {% macro href() %}
-    {% if module.link.url.href != "" %}
+  {# Sets attributes used for the link field #}
+  {% macro link_attributes() %}
+    {% set link_attributes = {} %}
+    
+    {# Setting href #}
+    {% if module.button_link.url.href != '' %}
       {# If the URL type is set to email, append `mailto:` in front of the inputted value #}
-      {% if module.link.url.type is equalto "EMAIL_ADDRESS" %}
-        {{ { 'href': 'mailto:' ~ module.link.url.href }|xmlattr }}
+      {% if module.button_link.url.type is equalto 'EMAIL_ADDRESS' %}
+        {% set href = link_attributes.update({'href': 'mailto:' ~ module.button_link.url.href}) %}
       {% else %}
-        {# Rule check:
-          Unless the URL entered has http:// or  https:// at the front,
-          is a telephone number (sniffed out by the value containing `tel:),
-          or the URL field doesn't have a value (because one of the other link types was chosen),
-          set the href variable to be `//` and append the entered URL string.
-          Otherwise, set the href to the exact value (unless its false or undefined then set it to be empty) 
-        #}
-        {% unless (module.link.url.href is string_containing "//")
-          or (!module.link is string_startingwith "tel:")
-          or !module.link.url.href
-        %}
-          {{ { 'href': '//' ~ module.link.url.href }|xmlattr }}
-        {% else %}
-          {{ { 'href': module.link.url.href || "" }|xmlattr }}
-        {% endunless %}
+        {% set href = link_attributes.update({'href': module.button_link.url.href}) %}
       {% endif %}
     {% endif %}
+
+    {# Setting the link's target and rel attributes based on the 'open in new tab' and 'tell search engines not to follow this link' fields being toggled #}
+    {% if module.button_link.no_follow && module.button_link.open_in_new_tab %}  
+      {% set rel = link_attributes.update({'rel': 'noopener nofollow', 'target': '_blank'})%}
+    {% elif module.button_link.no_follow %}
+        {% set rel = link_attributes.update({'rel': 'nofollow'})%}
+    {% elif module.button_link.open_in_new_tab %}
+      {% set rel = link_attributes.update({'rel': 'noopener', 'target': '_blank'})%}
+    {% endif %}
+
+    {{ link_attributes|xmlattr }}
   {% endmacro %}
-
-  {# Setting the link's target attribute to blank if the 'open in new tab' field is toggled #}
-  {% if module.link.open_in_new_tab %}
-    {% set target = 'target="_blank"'%}
-  {% endif %}
-
-  {# Checking to see if either field is toggled 'true' #}
-  {% if module.link.open_in_new_tab || module.link.no_follow %}
-    {# Setting the link's rel attribute to noopener if the 'open in new tab' field is toggled. Also setting it to nofollow if the 'tell search engines not to follow this link' field is toggled #}
-    {% set rel = 'rel="' ~ (module.link.open_in_new_tab ? "noopener " : null) ~ (module.link.no_follow ? "nofollow" : null) ~ '"' %}
-  {% endif %}
 
   {# Button #}
 
   <div class="button-wrapper">
-    <a class="button" {{ href() }} {{ target }} {{ rel }}>{{ module.button_text }}</a>
+    <a class="button" {{ link_attributes() }}>{{ module.button_text }}</a>
   </div>
 
 {% endif %}

--- a/src/modules/button.module/module.html
+++ b/src/modules/button.module/module.html
@@ -34,14 +34,37 @@
 
       .button:hover,
       .button:focus {
-        {% if module.styles.background.color.color %}
-          background-color: rgba({{ color_variant(module.styles.background.color.color, -80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% if module.styles.hover.background.color.color %}
+          background-color: rgba({{ module.styles.hover.background.color.color|convert_rgb }}, {{ module.styles.hover.background.color.opacity / 100 }});
+        {% endif %}
+        {{ module.styles.hover.border.border.css }}
+        {% if module.styles.hover.text.font.color %}
+          color: {{ module.styles.hover.text.font.color }};
+        {% endif %}
+        {% if module.styles.hover.text.font.size %}
+          font-size: {{ module.styles.hover.text.font.size ~ module.styles.hover.text.font.size_unit }};
+        {% endif %}
+        {% if module.styles.hover.text.font.style %}
+          {{ module.styles.hover.text.font.style }};
         {% endif %}
       }
 
       .button:active {
-        {% if module.styles.background.color.color %}
-          background-color: rgba({{ color_variant(module.styles.background.color.color, 80)|convert_rgb }}, {{ module.styles.background.color.opacity / 100 }});
+        {% if module.styles.hover.background.color.color %}
+          background-color: rgba({{ color_variant(module.styles.hover.background.color.color, 80)|convert_rgb }}, {{ module.styles.hover.background.color.opacity / 100 }});
+        {% endif %}
+        {{ module.styles.hover.border.border.css }}
+        {% if module.styles.hover.border.border %}
+          border-color: {{ color_variant(module.styles.hover.border.border.top.color, 80) }};
+        {% endif %}
+        {% if module.styles.hover.text.font.color %}
+          color: {{ module.styles.hover.text.font.color }};
+        {% endif %}
+        {% if module.styles.hover.text.font.size %}
+          font-size: {{ module.styles.hover.text.font.size ~ module.styles.hover.text.font.size_unit }};
+        {% endif %}
+        {% if module.styles.hover.text.font.style %}
+          {{ module.styles.hover.text.font.style }};
         {% endif %}
       }
 


### PR DESCRIPTION
- Adding CTA field and choice between button and CTA to the module
- Adjusting visibility of style fields when CTA is selected so they are hidden

**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This PR adds CTA functionality to the button module in the theme by:

- Adding a choice field to choose between a button and CTA
- Adding the if statement for the swap between markup
- Setting visibility on the style fields so that they don't show up if CTA is chosen
- Additionally, there are some markup changes: 
    - encloses the href, target, and rel statements inside a macro and cleaning up floating href attribute when link is not set 
    - ~Also adds further checks for telephone numbers, relative links, etc. for the href value.~ _This wasn't necessary based on recent updated to the validation in the UI_
    - Lastly, I've adjusted the rel attribute markup as well to remove the floating rel present when neither option is toggled
- Adding hover style field options and `:hover` and `:active` declarations to the scoped CSS of the module

**Relevant links**

[DM Previewer](hhttps://app.hubspot.com/design-previewer/7049788/modules/54992047957)

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.