### PR TITLE
Move main element to base.html

### DIFF
--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -7,43 +7,38 @@
 {% extends './layouts/base.html' %}
 
 {% block body %}
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--about'
+%}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Two column image left #}
 
-<main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--about'
+  {% dnd_section
+    vertical_alignment='TOP'
   %}
-
-    {# Two column image left #}
-
-    {% dnd_section
-      vertical_alignment='TOP'
+    {% dnd_module
+      path='@hubspot/linked_image',
+      img={
+        'alt': 'Coworkers sitting together and smiling outside.',
+        'loading': 'disabled',
+        'max_height': 449,
+        'max_width': 605,
+        'size_type': 'auto_custom_max',
+        'src': get_asset_url('../images/team-image.jpg')
+      },
+      offset=0,
+      width=6
     %}
-      {% dnd_module
-        path='@hubspot/linked_image',
-        img={
-          'alt': 'Coworkers sitting together and smiling outside.',
-          'loading': 'disabled',
-          'max_height': 449,
-          'max_width': 605,
-          'size_type': 'auto_custom_max',
-          'src': get_asset_url('../images/team-image.jpg')
-        },
-        offset=0,
-        width=6
-      %}
-      {% end_dnd_module %}
-      {% dnd_module
-        path='@hubspot/rich_text',
-        html='<h1>Meet our team</h1><p>Use this page to help your visitors learn more about you. Include images so that folks will recognize you at conferences and events.</p>'
-        offset=6,
-        width=6
-      %}
-      {% end_dnd_module %}
-    {% end_dnd_section %}
+    {% end_dnd_module %}
+    {% dnd_module
+      path='@hubspot/rich_text',
+      html='<h1>Meet our team</h1><p>Use this page to help your visitors learn more about you. Include images so that folks will recognize you at conferences and events.</p>'
+      offset=6,
+      width=6
+    %}
+    {% end_dnd_module %}
+  {% end_dnd_section %}
 
-  {% end_dnd_area %}
-</main>
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/blog-index.html
+++ b/src/templates/blog-index.html
@@ -8,70 +8,65 @@
 {% extends './layouts/base.html' %}
 
 {% block body %}
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--blog-index'
+%}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Hero banner #}
 
-<main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--blog-index'
-  %}
-
-    {# Hero banner #}
-
-    {% dnd_section
-      background_color='#f8fafc',
-      max_width=600,
-      padding={
-        'default': {
-          'top': 80,
-          'right': 0,
-          'bottom': 80,
-          'left': 0
-        },
-        'mobile': {
-          'top': 80,
-          'right': 20,
-          'bottom': 80,
-          'left': 20
-        }
+  {% dnd_section
+    background_color='#f8fafc',
+    max_width=600,
+    padding={
+      'default': {
+        'top': 80,
+        'right': 0,
+        'bottom': 80,
+        'left': 0
+      },
+      'mobile': {
+        'top': 80,
+        'right': 20,
+        'bottom': 80,
+        'left': 20
       }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module
-            path='@hubspot/rich_text',
-            html='<div style="text-align: center;"><h1>Blog</h1><p>Use this space to tell everyone about what you have to offer.</p></div>'
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-        {% dnd_row %}
-          {% dnd_module
-            path='@hubspot/blog_subscribe',
-            title=''
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
+    }
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module
+          path='@hubspot/rich_text',
+          html='<div style="text-align: center;"><h1>Blog</h1><p>Use this space to tell everyone about what you have to offer.</p></div>'
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+      {% dnd_row %}
+        {% dnd_module
+          path='@hubspot/blog_subscribe',
+          title=''
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
 
-    {# Blog listings and pagination #}
+  {# Blog listings and pagination #}
 
-    {% dnd_section
-      vertical_alignment='TOP'
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='../modules/blog-listings' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-        {% dnd_row %}
-          {% dnd_module path='../modules/blog-pagination' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
+  {% dnd_section
+    vertical_alignment='TOP'
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='../modules/blog-listings' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+      {% dnd_row %}
+        {% dnd_module path='../modules/blog-pagination' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
 
-  {% end_dnd_area %}
-</main>
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/blog-post.html
+++ b/src/templates/blog-post.html
@@ -8,87 +8,82 @@
 {% extends './layouts/base.html' %}
 
 {% block body %}
+<div class="body-container body-container--blog-post">
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Blog post #}
 
-<main id="main-content" class="body-container-wrapper">
-  <div class="body-container body-container--blog-post">
-
-    {# Blog post #}
-
-    <div class="content-wrapper">
-      <article class="blog-post">
-        <h1>{{ content.name }}</h1>
-        <div class="blog-post__meta">
-          <a href="{{ blog_author_url(group.id, content.blog_post_author.slug) }}" rel="author">
-            {{ content.blog_post_author.display_name }}
-          </a>
-          <time datetime="{{ content.publish_date }}" class="blog-post__timestamp">
-            {{ content.publish_date_localized }}
-          </time>
-        </div>
-        <div class="blog-post__body">
-          {{ content.post_body }}
-        </div>
-        {% if content.tag_list %}
-          <div class="blog-post__tags">
-            {% icon
-              name='tag',
-              purpose='decorative',
-              style='SOLID'
-            %}
-            {% for tag in content.tag_list %}
-              <a class="blog-post__tag-link" href="{{ blog_tag_url(group.id, tag.slug) }}" rel="tag">{{ tag.name }}</a>{% if not loop.last %},{% endif %}
-            {% endfor %}
-          </div>
-        {% endif %}
-      </article>
-      {% if group.allow_comments %}
-        <div class="blog-comments">
-          {% module 'blog_comments'
-            path='@hubspot/blog_comments',
-            label="Blog comments"
+  <div class="content-wrapper">
+    <article class="blog-post">
+      <h1>{{ content.name }}</h1>
+      <div class="blog-post__meta">
+        <a href="{{ blog_author_url(group.id, content.blog_post_author.slug) }}" rel="author">
+          {{ content.blog_post_author.display_name }}
+        </a>
+        <time datetime="{{ content.publish_date }}" class="blog-post__timestamp">
+          {{ content.publish_date_localized }}
+        </time>
+      </div>
+      <div class="blog-post__body">
+        {{ content.post_body }}
+      </div>
+      {% if content.tag_list %}
+        <div class="blog-post__tags">
+          {% icon
+            name='tag',
+            purpose='decorative',
+            style='SOLID'
           %}
+          {% for tag in content.tag_list %}
+            <a class="blog-post__tag-link" href="{{ blog_tag_url(group.id, tag.slug) }}" rel="tag">{{ tag.name }}</a>{% if not loop.last %},{% endif %}
+          {% endfor %}
         </div>
       {% endif %}
-    </div>
-
-    {# Recent posts listing #}
-
-    {# This macro is used to format each recent post card and gets passed to the related_blog_posts HubL tag below #}
-
-    {% macro related_posts(post, count, total) %}
-      {% if count == 1 %}
-        <section class="blog-related-posts">
-          <div class="content-wrapper">
-            <h2>Read On</h2>
-            <div class="blog-related-posts__list">
-      {% endif %}
-              <article class="blog-related-posts__post" aria-label="Blog post summary: {{ post.name }}">
-                {% if post.featured_image %}
-                  <a class="blog-related-posts__post-image-wrapper" href="{{ post.absolute_url }}" aria-label="{% if post.featured_image_alt_text %} Featured image: {{ post.featured_image_alt_text }} - {% endif %}Read full post: {{ post.name }}">
-                    <img class="blog-related-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{{ post.featured_image_alt_text }}">
-                  </a>
-                {% endif %}
-                <div class="blog-related-posts__content">
-                  <h3 class="blog-related-posts__title">
-                    <a class="blog-related-posts__title-link" href="{{ post.absolute_url }}">{{ post.name }}</a></h3>
-                  {{ post.post_summary|truncatehtml(100) }}
-                </div>
-              </article>
-        {% if count == total %}
-            </div>
-          </div>
-        </section>
-      {% endif %}
-    {% endmacro %}
-
-    {% related_blog_posts
-      limit=3,
-      no_wrapper=True,
-      post_formatter="related_posts"
-    %}
-
+    </article>
+    {% if group.allow_comments %}
+      <div class="blog-comments">
+        {% module 'blog_comments'
+          path='@hubspot/blog_comments',
+          label="Blog comments"
+        %}
+      </div>
+    {% endif %}
   </div>
-</main>
+
+  {# Recent posts listing #}
+
+  {# This macro is used to format each recent post card and gets passed to the related_blog_posts HubL tag below #}
+
+  {% macro related_posts(post, count, total) %}
+    {% if count == 1 %}
+      <section class="blog-related-posts">
+        <div class="content-wrapper">
+          <h2>Read On</h2>
+          <div class="blog-related-posts__list">
+    {% endif %}
+            <article class="blog-related-posts__post" aria-label="Blog post summary: {{ post.name }}">
+              {% if post.featured_image %}
+                <a class="blog-related-posts__post-image-wrapper" href="{{ post.absolute_url }}" aria-label="{% if post.featured_image_alt_text %} Featured image: {{ post.featured_image_alt_text }} - {% endif %}Read full post: {{ post.name }}">
+                  <img class="blog-related-posts__image" src="{{ post.featured_image }}" loading="lazy" width="352" alt="{{ post.featured_image_alt_text }}">
+                </a>
+              {% endif %}
+              <div class="blog-related-posts__content">
+                <h3 class="blog-related-posts__title">
+                  <a class="blog-related-posts__title-link" href="{{ post.absolute_url }}">{{ post.name }}</a></h3>
+                {{ post.post_summary|truncatehtml(100) }}
+              </div>
+            </article>
+      {% if count == total %}
+          </div>
+        </div>
+      </section>
+    {% endif %}
+  {% endmacro %}
+
+  {% related_blog_posts
+    limit=3,
+    no_wrapper=True,
+    post_formatter="related_posts"
+  %}
+
+</div>
 {% endblock body %}

--- a/src/templates/contact.html
+++ b/src/templates/contact.html
@@ -7,19 +7,14 @@
 {% extends './layouts/base.html' %}
 
 {% block body %}
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--contact'
+%}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Cards #}
 
-<main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--contact'
-  %}
+  {% include_dnd_partial path='../sections/cards.html' %}
 
-    {# Cards #}
-
-    {% include_dnd_partial path='../sections/cards.html' %}
-
-  {% end_dnd_area %}
-</main>
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -8,62 +8,57 @@
 
 {% block body %}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+{# All templates are recommended to have an h1 present for both accessibility and SEO best practice. This should be at the top of the template before any other textual content. The h1 element below is within a dnd area to allow content editors the ability to adjust the content and alignment of the text. #}
 
-<main id="main-content" class="body-container-wrapper">
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--home'
+%}
 
-  {# All templates are recommended to have an h1 present for both accessibility and SEO best practice. This should be at the top of the template before any other textual content. The h1 element below is within a dnd area to allow content editors the ability to adjust the content and alignment of the text. #}
+  {# Hero banner #}
 
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--home'
+  {% include_dnd_partial path='../sections/hero-banner.html' %}
+
+  {# Two column image right #}
+
+  {% include_dnd_partial path='../sections/multi-row-content.html' %}
+
+  {# Two column image left #}
+
+  {% dnd_section
+    background_color='#f8fafc',
+    vertical_alignment='MIDDLE'
   %}
-
-    {# Hero banner #}
-
-    {% include_dnd_partial path='../sections/hero-banner.html' %}
-
-    {# Two column image right #}
-
-    {% include_dnd_partial path='../sections/multi-row-content.html' %}
-
-    {# Two column image left #}
-
-    {% dnd_section
-      background_color='#f8fafc',
-      vertical_alignment='MIDDLE'
+    {% dnd_module
+      path='@hubspot/linked_image',
+      img={
+        'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
+        'loading': 'lazy',
+        'max_height': 451,
+        'max_width': 605,
+        'size_type': 'auto_custom_max',
+        'src': get_asset_url('../images/grayscale-mountain.png')
+      },
+      offset=0,
+      width=6
     %}
-      {% dnd_module
-        path='@hubspot/linked_image',
-        img={
-          'alt': 'Stock placeholder image with grayscale geometrical mountain landscape',
-          'loading': 'lazy',
-          'max_height': 451,
-          'max_width': 605,
-          'size_type': 'auto_custom_max',
-          'src': get_asset_url('../images/grayscale-mountain.png')
-        },
-        offset=0,
-        width=6
-      %}
-      {% end_dnd_module %}
-      {% dnd_module
-        path='@hubspot/rich_text',
-        html='<h2>Provide more details here.</h2><p>Use text and images to tell your company’s story. Explain what makes your product or service extraordinary.</p>'
-        offset=6,
-        width=6
-      %}
-      {% end_dnd_module %}
-    {% end_dnd_section %}
+    {% end_dnd_module %}
+    {% dnd_module
+      path='@hubspot/rich_text',
+      html='<h2>Provide more details here.</h2><p>Use text and images to tell your company’s story. Explain what makes your product or service extraordinary.</p>'
+      offset=6,
+      width=6
+    %}
+    {% end_dnd_module %}
+  {% end_dnd_section %}
 
-    {# Call to action #}
+  {# Call to action #}
 
-    {% include_dnd_partial path='../sections/call-to-action.html' %}
+  {% include_dnd_partial path='../sections/call-to-action.html' %}
 
-    {# Three column image with text #}
+  {# Three column image with text #}
 
-    {% include_dnd_partial path='../sections/multi-column-content.html' %}
+  {% include_dnd_partial path='../sections/multi-column-content.html' %}
 
-  {% end_dnd_area %}
-</main>
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/hubdb.html
+++ b/src/templates/hubdb.html
@@ -37,85 +37,80 @@
 {% set rows = hubdb_table_rows( table_id ) %}
 
 {% block body %}
+<div class="body-container body-container--hubdb">
+  <section class="content-wrapper content-wrapper--vertical-spacing">
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+    {% if table_id %}
 
-<main id="main-content" class="body-container-wrapper">
-  <div class="body-container body-container--hubdb">
-    <section class="content-wrapper content-wrapper--vertical-spacing">
+      {% if page_level == 0 and rows|length > 0 %}
+        <header>
+          <h1>
+            {% module "page_title" path="@hubspot/text"
+              label="Page title",
+              value="Root Page Title"
+            %}
+          </h1>
+        </header>
 
-      {% if table_id %}
+        <ul>
+          {% for row in rows %}
+            <li>
+              <a href="{{ request.path }}/{{ row.hs_path }}">{{ row.name }}</a>
+            </li>
+          {% endfor %}
+        </ul>
 
-        {% if page_level == 0 and rows|length > 0 %}
-          <header>
-            <h1>
-              {% module "page_title" path="@hubspot/text"
-                label="Page title",
-                value="Root Page Title"
-              %}
-            </h1>
-          </header>
+      {% elif page_level == 1 and row %}
 
-          <ul>
-            {% for row in rows %}
-              <li>
-                <a href="{{ request.path }}/{{ row.hs_path }}">{{ row.name }}</a>
-              </li>
-            {% endfor %}
-          </ul>
+        <header>
+          <h1>{{ row.name }}</h1>
+        </header>
 
-        {% elif page_level == 1 and row %}
-
-          <header>
-            <h1>{{ row.name }}</h1>
-          </header>
-
-          <table>
-            <thead>
+        <table>
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>Name</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for col in hubdb_table( table_id ).columns %}
               <tr>
-                <th>Label</th>
-                <th>Name</th>
-                <th>Value</th>
+                <th>{{ col.label }}</th>
+                <td><code>{{ col.name }}</code></td>
+                <td>{{ row[ col.name ] }}</td>
               </tr>
-            </thead>
-            <tbody>
-              {% for col in hubdb_table( table_id ).columns %}
-                <tr>
-                  <th>{{ col.label }}</th>
-                  <td><code>{{ col.name }}</code></td>
-                  <td>{{ row[ col.name ] }}</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-
-        {% endif %}
-
-      {% else %}
-
-        {# Leverages HubSpot's editor class to only show an error message within the page editor if a user hasn't selected a HubDB table yet (https://designers.hubspot.com/how-to-make-custom-code-work-with-cms#using-hs-inline-edit-window-hsineditor) #}
-
-        {% require_js %}
-          <script>
-            const pageEditor = document.querySelector('.hs-inline-edit .body-container--hubdb > .content-wrapper');
-            if (pageEditor) {
-              const headerNode = document.createElement("h1");
-              const headerTextNode = document.createTextNode("Error: No HubDB table has been selected.");
-              headerNode.appendChild(headerTextNode);
-              pageEditor.appendChild(headerNode);
-
-              const linkNode = document.createElement('a');
-              const linkTextNode = document.createTextNode("Learn how to select a HubDB table");
-              linkNode.appendChild(linkTextNode);
-              linkNode.href = "https://knowledge.hubspot.com/cos-general/how-to-edit-hubdb-tables";
-              pageEditor.appendChild(linkNode);
-            }
-          </script>
-        {% end_require_js %}
+            {% endfor %}
+          </tbody>
+        </table>
 
       {% endif %}
-    </section>
 
-  </div>
-</main>
+    {% else %}
+
+      {# Leverages HubSpot's editor class to only show an error message within the page editor if a user hasn't selected a HubDB table yet (https://designers.hubspot.com/how-to-make-custom-code-work-with-cms#using-hs-inline-edit-window-hsineditor) #}
+
+      {% require_js %}
+        <script>
+          const pageEditor = document.querySelector('.hs-inline-edit .body-container--hubdb > .content-wrapper');
+          if (pageEditor) {
+            const headerNode = document.createElement("h1");
+            const headerTextNode = document.createTextNode("Error: No HubDB table has been selected.");
+            headerNode.appendChild(headerTextNode);
+            pageEditor.appendChild(headerNode);
+
+            const linkNode = document.createElement('a');
+            const linkTextNode = document.createTextNode("Learn how to select a HubDB table");
+            linkNode.appendChild(linkTextNode);
+            linkNode.href = "https://knowledge.hubspot.com/cos-general/how-to-edit-hubdb-tables";
+            pageEditor.appendChild(linkNode);
+          }
+        </script>
+      {% end_require_js %}
+
+    {% endif %}
+  </section>
+
+</div>
 {% endblock %}

--- a/src/templates/landing-page.html
+++ b/src/templates/landing-page.html
@@ -11,33 +11,28 @@
 {% endblock header %}
 
 {% block body %}
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--landing-page'
+%}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Hero banner #}
 
-<main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--landing-page'
+  {% include_dnd_partial
+    path='../sections/hero-banner.html'
+    context={
+      'content': '<h1>Download your free eBook</h1><p>Use this space to tell everyone what your eBook is all about.</p>',
+    }
   %}
 
-    {# Hero banner #}
+  {# Three column image with text #}
 
-    {% include_dnd_partial
-      path='../sections/hero-banner.html'
-      context={
-        'content': '<h1>Download your free eBook</h1><p>Use this space to tell everyone what your eBook is all about.</p>',
-      }
-    %}
+  {% include_dnd_partial
+    path='../sections/multi-column-content.html',
+    context={
+      'background_color': '#FFFFFF'
+    }
+  %}
 
-    {# Three column image with text #}
-
-    {% include_dnd_partial
-      path='../sections/multi-column-content.html',
-      context={
-        'background_color': '#FFFFFF'
-      }
-    %}
-
-  {% end_dnd_area %}
-</main>
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/layouts/base.html
+++ b/src/templates/layouts/base.html
@@ -23,8 +23,12 @@
         {% global_partial path='../partials/header.html' %}
       {% endblock header %}
 
-      {% block body %}
-      {% endblock body %}
+      {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+
+      <main id="main-content" class="body-container-wrapper">
+        {% block body %}
+        {% endblock body %}
+      </main>
 
       {% block footer %}
         {% global_partial path='../partials/footer.html' %}

--- a/src/templates/pricing.html
+++ b/src/templates/pricing.html
@@ -7,19 +7,14 @@
 {% extends './layouts/base.html' %}
 
 {% block body %}
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--pricing'
+%}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Pricing #}
 
-<main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--pricing'
-  %}
+  {% include_dnd_partial path='../sections/pricing.html' %}
 
-    {# Pricing #}
-
-    {% include_dnd_partial path='../sections/pricing.html' %}
-
-  {% end_dnd_area %}
-</main>
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/qa-test.html
+++ b/src/templates/qa-test.html
@@ -7,648 +7,643 @@
 {% extends './layouts/base.html' %}
 
 {% block body %}
+{% dnd_area 'dnd_area'
+  label='Main section',
+  class='body-container body-container--qa-test'
+%}
 
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
+  {# Typography section #}
 
-<main id="main-content" class="body-container-wrapper">
-  {% dnd_area 'dnd_area'
-    label='Main section',
-    class='body-container body-container--qa-test'
+  {% dnd_section %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h1>Typography</h1>
+            <hr>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h1>Heading 1</h1>
+            <h2>Heading 2</h2>
+            <h3>Heading 3</h3>
+            <h4>Heading 4</h4>
+            <h5>Heading 5</h5>
+            <h6>Heading 6</h6>
+            <p>Lorem ipsum dolor sit amet, consectetur <em>adipiscing elit</em>. Duis porttitor, quam vel <strong>dignissim</strong> tincidunt, odio libero porta ligula, vitae fermentum lacus libero vel risus. Aenean pulvinar nisl et <a href="#">vestibulum commodo</a>. Quisque euismod tempus dignissim. Quisque dictum luctus velit, eu viverra urna tristique non. Vivamus at dolor tellus. Cras congue sapien non turpis dapibus, et vestibulum ante ultrices. Mauris eu nisi non sapien fermentum fermentum in eu odio. Fusce congue elit et tortor sagittis, sit amet auctor risus sagittis.</p>
+            <p>This line contains <sub>subscript</sub> text.</p>
+            <p>This line contains <sup>superscript</sup> text.</p>
+            <p>This line contains <code>code</code>.</p>
+            <p>This line contains <small>small</small> text.</p>
+            <p>This line contains <mark>highlighted</mark> text</p>
+            <pre><code>.preformatted-code { background-color: #FFF; }</code></pre>
+            <ul>
+            <li>Unordered list item</li>
+            <li>Unordered list item</li>
+            <li>Unordered list item</li>
+            <li>Unordered list item</li>
+            </ul>
+            <ol>
+            <li>First ordered list item</li>
+            <li>Second ordered list item</li>
+            <li>Third ordered list item</li>
+            <li>Fourth ordered list item</li>
+            </ol>
+            <blockquote>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis porttitor, quam vel dignissim tincidunt, odio libero porta ligula, vitae fermentum lacus libero vel risus. Aenean pulvinar nisl et vestibulum commodo. Quisque euismod tempus dignissim.</blockquote>
+            <table>
+              <thead>
+                <tr>
+                  <th>Header column one</th>
+                  <th>Header column two</th>
+                  <th>Header column three</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Row one column one</td>
+                  <td>Row one column two</td>
+                  <td>Row one column three</td>
+                </tr>
+                <tr>
+                  <td>Row two column one</td>
+                  <td>Row two column two</td>
+                  <td>Row two column three</td>
+                </tr>
+                <tr>
+                  <td>Row three column one</td>
+                  <td>Row three column two</td>
+                  <td>Row three column three</td>
+                </tr>
+                <tr>
+                  <td>Row four column one</td>
+                  <td>Row four column two</td>
+                  <td>Row four column three</td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td>Footer column one</td>
+                  <td>Footer column two</td>
+                  <td>Footer column three</td>
+                </tr>
+              </tfoot>
+            </table>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {# Default modules section #}
+
+  {% dnd_section %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h2>Default modules </h2>
+            <hr>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Forms #}
+
+      {% dnd_row
+        margin={
+          'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Forms</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# One column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/form' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+
+      {# Two column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/form',
+          offset=0,
+          width=6
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='@hubspot/form',
+          offset=6,
+          width=6
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Three column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/form',
+          offset=0,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='@hubspot/form',
+          offset=4,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='@hubspot/form',
+          offset=8,
+          width=4
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {# Theme modules section #}
+
+  {% dnd_section %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h2>Theme modules</h2>
+            <hr>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Card #}
+
+      {% dnd_row
+        margin={
+          'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Card</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# One column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/card' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Two column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/card',
+          offset=0,
+          width=6
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/card',
+          offset=6,
+          width=6
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Three column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/card',
+          offset=0,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/card',
+          offset=4,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/card',
+          offset=8,
+          width=4
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Button #}
+
+      {% dnd_row
+        margin={
+          'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Button</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# One column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/button' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Two column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/button',
+          offset=0,
+          width=6
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/button',
+          offset=6,
+          width=6
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Three column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/button',
+          offset=0,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/button',
+          offset=4,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/button',
+          offset=8,
+          width=4
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Menu #}
+
+      {% dnd_row
+        margin={
+          'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Menu section</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+      {% dnd_row %}
+        {% dnd_module path='../modules/menu' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Pricing card #}
+
+      {% dnd_row
+        margin={
+          'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Pricing card</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# One column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/pricing-card' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Two column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/pricing-card',
+          offset=0,
+          width=6
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/pricing-card',
+          offset=6,
+          width=6
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Three column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/pricing-card',
+          offset=0,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/pricing-card',
+          offset=4,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/pricing-card',
+          offset=8,
+          width=4
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Social follow #}
+
+      {% dnd_row
+        margin={
+          'top': 35
+        }
+      %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Social follow</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# One column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/social-follow' %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Two column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/social-follow',
+          offset=0,
+          width=6
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/social-follow',
+          offset=6,
+          width=6
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+
+      {# Three column #}
+
+      {% dnd_row
+        padding={
+        'top': 35
+        }
+      %}
+        {% dnd_module path='../modules/social-follow',
+          offset=0,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/social-follow',
+          offset=4,
+          width=4
+        %}
+        {% end_dnd_module %}
+        {% dnd_module path='../modules/social-follow',
+          offset=8,
+          width=4
+        %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {# Theme sections #}
+
+  {% dnd_section %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h2>Theme sections</h2>
+            <hr>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {# Call to action #}
+
+  {% dnd_section
+    padding={
+      'top': 0,
+      'bottom': 0
+    },
+    margin={
+      'top': 35
+    }
   %}
-
-    {# Typography section #}
-
-    {% dnd_section %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h1>Typography</h1>
-              <hr>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h1>Heading 1</h1>
-              <h2>Heading 2</h2>
-              <h3>Heading 3</h3>
-              <h4>Heading 4</h4>
-              <h5>Heading 5</h5>
-              <h6>Heading 6</h6>
-              <p>Lorem ipsum dolor sit amet, consectetur <em>adipiscing elit</em>. Duis porttitor, quam vel <strong>dignissim</strong> tincidunt, odio libero porta ligula, vitae fermentum lacus libero vel risus. Aenean pulvinar nisl et <a href="#">vestibulum commodo</a>. Quisque euismod tempus dignissim. Quisque dictum luctus velit, eu viverra urna tristique non. Vivamus at dolor tellus. Cras congue sapien non turpis dapibus, et vestibulum ante ultrices. Mauris eu nisi non sapien fermentum fermentum in eu odio. Fusce congue elit et tortor sagittis, sit amet auctor risus sagittis.</p>
-              <p>This line contains <sub>subscript</sub> text.</p>
-              <p>This line contains <sup>superscript</sup> text.</p>
-              <p>This line contains <code>code</code>.</p>
-              <p>This line contains <small>small</small> text.</p>
-              <p>This line contains <mark>highlighted</mark> text</p>
-              <pre><code>.preformatted-code { background-color: #FFF; }</code></pre>
-              <ul>
-              <li>Unordered list item</li>
-              <li>Unordered list item</li>
-              <li>Unordered list item</li>
-              <li>Unordered list item</li>
-              </ul>
-              <ol>
-              <li>First ordered list item</li>
-              <li>Second ordered list item</li>
-              <li>Third ordered list item</li>
-              <li>Fourth ordered list item</li>
-              </ol>
-              <blockquote>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis porttitor, quam vel dignissim tincidunt, odio libero porta ligula, vitae fermentum lacus libero vel risus. Aenean pulvinar nisl et vestibulum commodo. Quisque euismod tempus dignissim.</blockquote>
-              <table>
-                <thead>
-                  <tr>
-                    <th>Header column one</th>
-                    <th>Header column two</th>
-                    <th>Header column three</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Row one column one</td>
-                    <td>Row one column two</td>
-                    <td>Row one column three</td>
-                  </tr>
-                  <tr>
-                    <td>Row two column one</td>
-                    <td>Row two column two</td>
-                    <td>Row two column three</td>
-                  </tr>
-                  <tr>
-                    <td>Row three column one</td>
-                    <td>Row three column two</td>
-                    <td>Row three column three</td>
-                  </tr>
-                  <tr>
-                    <td>Row four column one</td>
-                    <td>Row four column two</td>
-                    <td>Row four column three</td>
-                  </tr>
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <td>Footer column one</td>
-                    <td>Footer column two</td>
-                    <td>Footer column three</td>
-                  </tr>
-                </tfoot>
-              </table>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {# Default modules section #}
-
-    {% dnd_section %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h2>Default modules </h2>
-              <hr>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Forms #}
-
-        {% dnd_row
-          margin={
-            'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Forms</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# One column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/form' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-
-        {# Two column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/form',
-            offset=0,
-            width=6
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='@hubspot/form',
-            offset=6,
-            width=6
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Three column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/form',
-            offset=0,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='@hubspot/form',
-            offset=4,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='@hubspot/form',
-            offset=8,
-            width=4
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {# Theme modules section #}
-
-    {% dnd_section %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h2>Theme modules</h2>
-              <hr>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Card #}
-
-        {% dnd_row
-          margin={
-            'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Card</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# One column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/card' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Two column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/card',
-            offset=0,
-            width=6
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/card',
-            offset=6,
-            width=6
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Three column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/card',
-            offset=0,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/card',
-            offset=4,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/card',
-            offset=8,
-            width=4
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Button #}
-
-        {% dnd_row
-          margin={
-            'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Button</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# One column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/button' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Two column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/button',
-            offset=0,
-            width=6
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/button',
-            offset=6,
-            width=6
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Three column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/button',
-            offset=0,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/button',
-            offset=4,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/button',
-            offset=8,
-            width=4
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Menu #}
-
-        {% dnd_row
-          margin={
-            'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Menu section</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-        {% dnd_row %}
-          {% dnd_module path='../modules/menu' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Pricing card #}
-
-        {% dnd_row
-          margin={
-            'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Pricing card</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# One column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/pricing-card' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Two column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/pricing-card',
-            offset=0,
-            width=6
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/pricing-card',
-            offset=6,
-            width=6
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Three column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/pricing-card',
-            offset=0,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/pricing-card',
-            offset=4,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/pricing-card',
-            offset=8,
-            width=4
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Social follow #}
-
-        {% dnd_row
-          margin={
-            'top': 35
-          }
-        %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Social follow</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# One column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/social-follow' %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Two column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/social-follow',
-            offset=0,
-            width=6
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/social-follow',
-            offset=6,
-            width=6
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-
-        {# Three column #}
-
-        {% dnd_row
-          padding={
-          'top': 35
-          }
-        %}
-          {% dnd_module path='../modules/social-follow',
-            offset=0,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/social-follow',
-            offset=4,
-            width=4
-          %}
-          {% end_dnd_module %}
-          {% dnd_module path='../modules/social-follow',
-            offset=8,
-            width=4
-          %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {# Theme sections #}
-
-    {% dnd_section %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h2>Theme sections</h2>
-              <hr>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {# Call to action #}
-
-    {% dnd_section
-      padding={
-        'top': 0,
-        'bottom': 0
-      },
-      margin={
-        'top': 35
-      }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Call to action</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {% include_dnd_partial path='../sections/call-to-action.html' %}
-
-    {# Cards #}
-
-    {% dnd_section
-      padding={
-        'top': 0,
-        'bottom': 0
-      },
-      margin={
-        'top': 35
-      }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Cards</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {% include_dnd_partial path='../sections/cards.html' %}
-
-    {# Hero banner #}
-
-    {% dnd_section
-      padding={
-        'top': 0,
-        'bottom': 0
-      },
-      margin={
-        'top': 35
-      }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Hero banner</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {% include_dnd_partial path='../sections/hero-banner.html' %}
-
-    {# Multi-column content #}
-
-    {% dnd_section
-      padding={
-        'top': 0,
-        'bottom': 0
-      },
-      margin={
-        'top': 35
-      }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Multi-column content</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {% include_dnd_partial path='../sections/multi-column-content.html' %}
-
-    {# Multi-row content #}
-
-    {% dnd_section
-      padding={
-        'top': 0,
-        'bottom': 0
-      },
-      margin={
-        'top': 35
-      }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Multi-row content</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {% include_dnd_partial path='../sections/multi-row-content.html' %}
-
-    {# Pricing #}
-
-    {% dnd_section
-      padding={
-        'top': 0,
-        'bottom': 0
-      },
-      margin={
-        'top': 35
-      }
-    %}
-      {% dnd_column %}
-        {% dnd_row %}
-          {% dnd_module path='@hubspot/rich_text' %}
-            {% module_attribute 'html' %}
-              <h3>Pricing</h3>
-            {% end_module_attribute %}
-          {% end_dnd_module %}
-        {% end_dnd_row %}
-      {% end_dnd_column %}
-    {% end_dnd_section %}
-
-    {% include_dnd_partial path='../sections/pricing.html' %}
-
-  {% end_dnd_area %}
-</main>
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Call to action</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {% include_dnd_partial path='../sections/call-to-action.html' %}
+
+  {# Cards #}
+
+  {% dnd_section
+    padding={
+      'top': 0,
+      'bottom': 0
+    },
+    margin={
+      'top': 35
+    }
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Cards</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {% include_dnd_partial path='../sections/cards.html' %}
+
+  {# Hero banner #}
+
+  {% dnd_section
+    padding={
+      'top': 0,
+      'bottom': 0
+    },
+    margin={
+      'top': 35
+    }
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Hero banner</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {% include_dnd_partial path='../sections/hero-banner.html' %}
+
+  {# Multi-column content #}
+
+  {% dnd_section
+    padding={
+      'top': 0,
+      'bottom': 0
+    },
+    margin={
+      'top': 35
+    }
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Multi-column content</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {% include_dnd_partial path='../sections/multi-column-content.html' %}
+
+  {# Multi-row content #}
+
+  {% dnd_section
+    padding={
+      'top': 0,
+      'bottom': 0
+    },
+    margin={
+      'top': 35
+    }
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Multi-row content</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {% include_dnd_partial path='../sections/multi-row-content.html' %}
+
+  {# Pricing #}
+
+  {% dnd_section
+    padding={
+      'top': 0,
+      'bottom': 0
+    },
+    margin={
+      'top': 35
+    }
+  %}
+    {% dnd_column %}
+      {% dnd_row %}
+        {% dnd_module path='@hubspot/rich_text' %}
+          {% module_attribute 'html' %}
+            <h3>Pricing</h3>
+          {% end_module_attribute %}
+        {% end_dnd_module %}
+      {% end_dnd_row %}
+    {% end_dnd_column %}
+  {% end_dnd_section %}
+
+  {% include_dnd_partial path='../sections/pricing.html' %}
+
+{% end_dnd_area %}
 {% endblock body %}

--- a/src/templates/system/404.html
+++ b/src/templates/system/404.html
@@ -10,28 +10,25 @@
 {% set pageTitle = "Error 404 | Page not found" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="error-page" data-error="404">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Page not found.</h1>'
-      %}
-      {% module 'button'
-        path='../../modules/button',
-        button_text='Go Home'
-        link={
-          'url':
-            {
-              'type': 'EXTERNAL',
-              'href': '/'
-            },
-            'open_in_new_tab': false,
-            'no_follow': false
-        }
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="error-page" data-error="404">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Page not found.</h1>'
+    %}
+    {% module 'button'
+      path='../../modules/button',
+      button_text='Go Home'
+      link={
+        'url':
+          {
+            'type': 'EXTERNAL',
+            'href': '/'
+          },
+          'open_in_new_tab': false,
+          'no_follow': false
+      }
+    %}
+  </div>
+</section>
 {% endblock body %}

--- a/src/templates/system/500.html
+++ b/src/templates/system/500.html
@@ -10,15 +10,12 @@
 {% set pageTitle = "Error 500 | Server error" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="error-page" data-error="500">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Something isn\'t quite right</h1><p>Sorry, an internal server error occurred. But have no fear, we\'re on the case!</p>'
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="error-page" data-error="500">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Something isn\'t quite right</h1><p>Sorry, an internal server error occurred. But have no fear, we\'re on the case!</p>'
+    %}
+  </div>
+</section>
 {% endblock body %}

--- a/src/templates/system/backup-unsubscribe.html
+++ b/src/templates/system/backup-unsubscribe.html
@@ -10,15 +10,12 @@
 {% set pageTitle = "Unsubscribe" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'backup_unsubscribe'
-        extra_classes='backup-unsubscribe',
-        path='@hubspot/email_simple_subscription'
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'backup_unsubscribe'
+      extra_classes='backup-unsubscribe',
+      path='@hubspot/email_simple_subscription'
+    %}
+  </div>
+</section>
 {% endblock body %}

--- a/src/templates/system/membership-login.html
+++ b/src/templates/system/membership-login.html
@@ -13,34 +13,31 @@
 {% endblock %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Sign in to view this page</h1><p>This page is only available to people who have been given access.</p>'
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Sign in to view this page</h1><p>This page is only available to people who have been given access.</p>'
+    %}
+    <div class="form-container">
+      {% member_login 'my_login'
+        email_label= 'Email',
+        password_label= 'Password',
+        remember_me_label= 'Remember Me',
+        reset_password_text= 'Forgot your password?',
+        submit_button_text= 'Login'
       %}
-      <div class="form-container">
-        {% member_login 'my_login'
-          email_label= 'Email',
-          password_label= 'Password',
-          remember_me_label= 'Remember Me',
-          reset_password_text= 'Forgot your password?',
-          submit_button_text= 'Login'
-        %}
-      </div>
-      <div>
-        {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
-        %}
-          {% module_attribute 'html' %}
-            <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
-          {% end_module_attribute %}
-        {% end_module_block %}
-      </div>
     </div>
-  </section>
-</main>
+    <div>
+      {% module_block module 'membership_admin_content'
+        label='Contact admin',
+        path='@hubspot/rich_text'
+      %}
+        {% module_attribute 'html' %}
+          <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/src/templates/system/membership-register.html
+++ b/src/templates/system/membership-register.html
@@ -13,33 +13,30 @@
 {% endblock %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Welcome!</h1><p>Set up your password to sign in and see the content you now have access to.</p>'
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Welcome!</h1><p>Set up your password to sign in and see the content you now have access to.</p>'
+    %}
+    <div class="form-container">
+      {% member_register 'my_register'
+        email_label='Email',
+        password_confirm_label='Confirm Password',
+        password_label='Password',
+        submit_button_text='Save Password'
       %}
-      <div class="form-container">
-        {% member_register 'my_register'
-          email_label='Email',
-          password_confirm_label='Confirm Password',
-          password_label='Password',
-          submit_button_text='Save Password'
-        %}
-      </div>
-      <div>
-        {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
-        %}
-          {% module_attribute 'html' %}
-            <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
-          {% end_module_attribute %}
-        {% end_module_block %}
-      </div>
     </div>
-  </section>
-</main>
+    <div>
+      {% module_block module 'membership_admin_content'
+        label='Contact admin',
+        path='@hubspot/rich_text'
+      %}
+        {% module_attribute 'html' %}
+          <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/src/templates/system/membership-reset-password-request.html
+++ b/src/templates/system/membership-reset-password-request.html
@@ -13,31 +13,28 @@
 {% endblock %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Reset your password</h1><p>What email address should we send a password reset email to?</p>'
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Reset your password</h1><p>What email address should we send a password reset email to?</p>'
+    %}
+    <div class="form-container">
+      {% password_reset_request 'my_password_reset_request'
+        email_label='Email',
+        submit_button_text='Send Reset Email'
       %}
-      <div class="form-container">
-        {% password_reset_request 'my_password_reset_request'
-          email_label='Email',
-          submit_button_text='Send Reset Email'
-        %}
-      </div>
-      <div>
-        {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
-        %}
-          {% module_attribute 'html' %}
-            <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
-          {% end_module_attribute %}
-        {% end_module_block %}
-      </div>
     </div>
-  </section>
-</main>
+    <div>
+      {% module_block module 'membership_admin_content'
+        label='Contact admin',
+        path='@hubspot/rich_text'
+      %}
+        {% module_attribute 'html' %}
+          <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/src/templates/system/membership-reset-password.html
+++ b/src/templates/system/membership-reset-password.html
@@ -13,32 +13,29 @@
 {% endblock %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Reset your password</h1><p>Enter a new password.</p>'
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Reset your password</h1><p>Enter a new password.</p>'
+    %}
+    <div class="form-container">
+      {% password_reset 'my_password_reset'
+        password_confirm_label='Confirm Password',
+        password_label='Password',
+        submit_button_text= 'Save Password'
       %}
-      <div class="form-container">
-        {% password_reset 'my_password_reset'
-          password_confirm_label='Confirm Password',
-          password_label='Password',
-          submit_button_text= 'Save Password'
-        %}
-      </div>
-      <div>
-        {% module_block module 'membership_admin_content'
-          label='Contact admin',
-          path='@hubspot/rich_text'
-        %}
-          {% module_attribute 'html' %}
-            <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
-          {% end_module_attribute %}
-        {% end_module_block %}
-      </div>
     </div>
-  </section>
-</main>
+    <div>
+      {% module_block module 'membership_admin_content'
+        label='Contact admin',
+        path='@hubspot/rich_text'
+      %}
+        {% module_attribute 'html' %}
+          <p>Having trouble? <a href="{{'mailto:' ~ site_settings.membershipWebsiteAdmin}}">Contact the admin</a>.</p>
+        {% end_module_attribute %}
+      {% end_module_block %}
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/src/templates/system/password-prompt.html
+++ b/src/templates/system/password-prompt.html
@@ -10,19 +10,16 @@
 {% set pageTitle = "This page is private | Enter password" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'content'
-        path='@hubspot/rich_text',
-        html='<h1>Password Required</h1><p>Please enter the password required to view this page.</p>'
-      %}
-      {% module 'password_prompt'
-        extra_classes='password-prompt',
-        path='@hubspot/password_prompt'
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'content'
+      path='@hubspot/rich_text',
+      html='<h1>Password Required</h1><p>Please enter the password required to view this page.</p>'
+    %}
+    {% module 'password_prompt'
+      extra_classes='password-prompt',
+      path='@hubspot/password_prompt'
+    %}
+  </div>
+</section>
 {% endblock body %}

--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -10,22 +10,19 @@
 {% set pageTitle = "Search results" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page systems-page--search-results">
-      {% module_block module 'search_results_content'
-        label='Search results heading',
-        path='@hubspot/rich_text'
-      %}
-        {% module_attribute 'html' %}
-          <h1>Results for "{{ request.query_dict.term|escape }}"</h1>
-        {% end_module_attribute %}
-      {% end_module_block %}
-      {% module 'search_results'
-        path='@hubspot/search_results'
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="systems-page systems-page--search-results">
+    {% module_block module 'search_results_content'
+      label='Search results heading',
+      path='@hubspot/rich_text'
+    %}
+      {% module_attribute 'html' %}
+        <h1>Results for "{{ request.query_dict.term|escape }}"</h1>
+      {% end_module_attribute %}
+    {% end_module_block %}
+    {% module 'search_results'
+      path='@hubspot/search_results'
+    %}
+  </div>
+</section>
 {% endblock body %}

--- a/src/templates/system/subscription-preferences.html
+++ b/src/templates/system/subscription-preferences.html
@@ -10,14 +10,11 @@
 {% set pageTitle = "Subscription preferences" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'subscription_preferences'
-        path='@hubspot/email_subscriptions'
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'subscription_preferences'
+      path='@hubspot/email_subscriptions'
+    %}
+  </div>
+</section>
 {% endblock body %}

--- a/src/templates/system/subscriptions-confirmation.html
+++ b/src/templates/system/subscriptions-confirmation.html
@@ -10,14 +10,11 @@
 {% set pageTitle = "Confirm subscriptions" %}
 
 {% block body %}
-{# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
-<main id="main-content" class="body-container-wrapper">
-  <section class="content-wrapper">
-    <div class="systems-page">
-      {% module 'subscriptions_confirmation'
-        path='@hubspot/email_subscriptions_confirmation'
-      %}
-    </div>
-  </section>
-</main>
+<section class="content-wrapper">
+  <div class="systems-page">
+    {% module 'subscriptions_confirmation'
+      path='@hubspot/email_subscriptions_confirmation'
+    %}
+  </div>
+</section>
 {% endblock body %}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Per suggestion of @jevenson we found that the `main` element and HubL comment above it was repeated for every template in boilerplate therefore to simplify the code it was moved to the `base.html` file. Per suggestion of @johnsfuller if someone wanted to add an aside that is adjacent to the `main` element they could add a new block for `aside` in `base.html` (example in linked GitHub issue below). 

**Relevant links**

Fixes #361 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
