### PR TITLE
Adjusting code for menu items without links

### DIFF
--- a/src/modules/menu.module/module.html
+++ b/src/modules/menu.module/module.html
@@ -85,7 +85,15 @@
 
   {% macro render_link_item(link, depth) %}
     <li class="menu__item menu__item--depth-{{ depth }} {{ 'menu__item--has-submenu' if link.children && depth < module.max_levels }} hs-skip-lang-url-rewrite">
-      <a class="menu__link {{ 'menu__link--toggle' if link.children && depth < module.max_levels }} {{ 'menu__link--active-branch' if link.activeBranch }} {{ 'menu__link--active-link' if link.activeNode }}" href="{{ link.url }}" {{ 'aria-haspopup="true" aria-expanded="false"' if link.children && depth < module.max_levels }} {{ 'aria-current="page"' if link.activeNode }} {{ 'target="_blank" rel="noopener"' if link.linkTarget }}>{{ link.label }}</a>
+      {% if link.url %}
+        <a class="menu__link {{ 'menu__link--toggle' if link.children && depth < module.max_levels }} {{ 'menu__link--active-branch' if link.activeBranch }} {{ 'menu__link--active-link' if link.activeNode }}" href="{{ link.url }}" {{ 'aria-haspopup="true" aria-expanded="false"' if link.children && depth < module.max_levels }} {{ 'aria-current="page"' if link.activeNode }} {{ 'target="_blank" rel="noopener"' if link.linkTarget }}>{{ link.label }}</a>
+      {% else %}
+        {% if link.children && depth < module.max_levels %}
+          <a class="menu__link menu__link--toggle" href="#" aria-haspopup="true" aria-expanded="false">{{ link.label }}</a>
+        {% else %}
+          <span class="menu__link">{{ link.label }}</span>
+        {% endif %}
+      {% endif %}
       {% if link.children %}
         {% if depth && depth < module.max_levels %}
           <button class="menu__child-toggle no-button" aria-expanded="false">


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Updates menu to account for menu items without a link. If the menu item without a link is a parent menu item/has children, we set the link to be: `<a class="menu__link menu__link--toggle" href="#" aria-haspopup="true" aria-expanded="false">{{ link.label }}</a>` otherwise if the menu item doesn't have a link _and_ doesn't have children we set the menu item to be `<span class="menu__link">{{ link.label }}</span>`. In this case we use a span to keep the menu items styled the same. 

[Example link](http://jrosa-102019231.hs-sitesqa.com/-temporary-slug-9cd7cf34-a3ff-48d4-8e45-57a987ddd6fe?hs_preview=iVKGGBFb-43115586653&#)

**Relevant links**

Fixes #377 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
