### PR TITLE
Updating boilerplate version to 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cms-theme-boilerplate",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Boilerplate project for building websites on the HubSpot CMS",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating boilerplate version to v3.1 to support the upcoming release. The plan is to set up the release for tomorrow afternoon. I want to let this last PR sit until tomorrow morning (https://github.com/HubSpot/cms-theme-boilerplate/pull/385) but if everything is good there I think we should be good for release. 