### PR TITLE
Update cli and deploy version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
       - name: HubSpot Deploy Action
-        uses: HubSpot/hubspot-cms-deploy-action@v1.3
+        uses: HubSpot/hubspot-cms-deploy-action@v1.4
         with:
           src_dir: src
           dest_dir: cms-theme-boilerplate

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@hubspot/cms-cli": "^2.2.0",
+    "@hubspot/cli": "^3.0.9",
     "autoprefixer": "^9.0.0",
     "eslint": "^7.9.0",
     "js-yaml": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@hubspot/cli": "^3.0.9",
     "autoprefixer": "^9.0.0",
     "eslint": "^7.9.0",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
Update CLI and deploy version to be update to date. The CLI in particular was pretty out of date. Deploy action would be going from 1.3 to 1.4 (https://github.com/marketplace/actions/hubspot-cms-deploy). 