### PR TITLE
Add inheritance from brand settings

### DIFF
--- a/src/fields.json
+++ b/src/fields.json
@@ -13,6 +13,11 @@
             "opacity": true
           }
         },
+        "inherited_value": {
+          "property_value_paths": {
+            "color": "brandSettings.primaryColor"
+          }
+        },
         "default": {
           "color": "#494A52"
         }
@@ -24,6 +29,11 @@
         "visibility": {
           "hidden_subfields": {
             "opacity": true
+          }
+        },
+        "inherited_value": {
+          "property_value_paths": {
+            "color": "brandSettings.colors[1]"
           }
         },
         "default": {
@@ -1211,8 +1221,12 @@
             "label": "Color",
             "name": "color",
             "type": "color",
+            "inherited_value": {
+              "property_value_paths": {
+                "color": "theme.global_colors.secondary.color"
+              }
+            },
             "default": {
-              "color": "#F8FAFC",
               "opacity": 100
             }
           }
@@ -1256,8 +1270,12 @@
             "label": "Color",
             "name": "color",
             "type": "color",
+            "inherited_value": {
+              "property_value_paths": {
+                "color": "theme.global_colors.secondary.color"
+              }
+            },
             "default": {
-              "color": "#F8FAFC",
               "opacity": 100
             }
           }


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [X] New feature (change which adds new functionality)

**Description**

Add brand inheritance from brand settings to theme settings. Documentation on this can be found [here](https://developers.hubspot.com/docs/cms/building-blocks/module-theme-fields/branding-settings-inheritance). This also makes a couple minor updates so the secondary color in boilerplate inherits down to header + footer background color. This might be a slightly breaking change so before a developer downloads this update it would be recommended to verify secondary color = website header + website footer bg color first. 

**Relevant links**

[Example theme editor](https://app.hubspotqa.com/theme-editor/102019231/edit/boilerplate-theme?fromAppName=pageEditor&redirectUrl=%2Fcontent%2F102019231%2Fedit%2F43605388638%2Fcontent&templatePath=boilerplate-theme%2Ftemplates%2Fhome.html)
Fixes #393 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
