### PR TITLE
update deploy action version number in GH workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
       - name: HubSpot Deploy Action
-        uses: HubSpot/hubspot-cms-deploy-action@v1.4
+        uses: HubSpot/hubspot-cms-deploy-action@v1.5
         with:
           src_dir: src
           dest_dir: cms-theme-boilerplate


### PR DESCRIPTION
**Types of change**

- [x] Bug fix (change which fixes an issue)

**Description**

Updates to use the latest published version of the GH action. That prior version may have had a bug preventing publishing.
Was reported by John Fuller of our dev community here:
https://hubspotdev.slack.com/archives/GUM1A8A9W/p1638991373123500?thread_ts=1638983484.122100&cid=GUM1A8A9W

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ ] I have thoroughly tested my change.

**People to notify**
@jasonnrosa @anthmatic 


Not really sure how I would really test this change other than forking the whole repo so thought I'd PR since I don't know if we have any specific concerns with how we handle the boilerplate example site etc.