### PR TITLE
Updating module rich text fields to use the rich text field config options

### DIFF
--- a/src/modules/card.module/fields.json
+++ b/src/modules/card.module/fields.json
@@ -21,38 +21,20 @@
         }
       },
       {
-        "label": "Title",
-        "name": "title",
-        "id": "card.title",
-        "type": "text",
-        "default": "This is a title"
-      },
-      {
-        "label": "Title heading type",
-        "name": "title_heading_type",
-        "type": "choice",
-        "choices": [
-          ["h1", "Heading 1"],
-          ["h2", "Heading 2"],
-          ["h3", "Heading 3"],
-          ["h4", "Heading 4"],
-          ["h5", "Heading 5"],
-          ["h6", "Heading 6"]
-        ],
-        "display": "select",
-        "required": true,
-        "visibility": {
-          "controlling_field": "card.title",
-          "controlling_value_regex": "",
-          "operator": "NOT_EQUAL"
-        },
-        "default": "h3"
-      },
-      {
         "label": "Content",
         "name": "text",
-        "type": "text",
-        "default": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
+        "type": "richtext",
+        "enabled_features": [
+          "advanced_emphasis",
+          "alignment",
+          "block",
+          "emoji",
+          "font_family",
+          "font_size",
+          "lists",
+          "standard_emphasis"
+        ],
+        "default": "<h3>This is a title</h3><p>Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more.</p>"
       }
     ],
     "default": [
@@ -60,25 +42,19 @@
         "image": {
           "loading": "lazy"
         },
-        "title": "This is a title",
-        "title_heading_type": "h3",
-        "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
+        "text": "<h3>This is a title</h3><p>Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more.</p>"
       },
       {
         "image": {
           "loading": "lazy"
         },
-        "title": "This is a title",
-        "title_heading_type": "h3",
-        "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
+        "text": "<h3>This is a title</h3><p>Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more.</p>"
       },
       {
         "image": {
           "loading": "lazy"
         },
-        "title": "This is a title",
-        "title_heading_type": "h3",
-        "text": "Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more."
+        "text": "<h3>This is a title</h3><p>Contextual advertising can be profitable. It can either pay for your hosting and maintenance costs for you website or it can pay for a lot more.</p>"
       }
     ]
   },
@@ -106,70 +82,6 @@
                 "max": 100,
                 "step": 1,
                 "suffix": "px"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "label": "Title",
-        "name": "title",
-        "type": "group",
-        "children": [
-          {
-            "label": "Text",
-            "name": "text",
-            "type": "group",
-            "children": [
-              {
-                "label": "Font",
-                "name": "font",
-                "type": "font"
-              }
-            ]
-          },
-          {
-            "label": "Alignment",
-            "name": "alignment",
-            "type": "group",
-            "children": [
-              {
-                "label": "Alignment",
-                "name": "alignment",
-                "type": "alignment",
-                "alignment_direction": "HORIZONTAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "label": "Content",
-        "name": "content",
-        "type": "group",
-        "children": [
-          {
-            "label": "Text",
-            "name": "text",
-            "type": "group",
-            "children": [
-              {
-                "label": "Font",
-                "name": "font",
-                "type": "font"
-              }
-            ]
-          },
-          {
-            "label": "Alignment",
-            "name": "alignment",
-            "type": "group",
-            "children": [
-              {
-                "label": "Alignment",
-                "name": "alignment",
-                "type": "alignment",
-                "alignment_direction": "HORIZONTAL"
               }
             ]
           }

--- a/src/modules/card.module/module.html
+++ b/src/modules/card.module/module.html
@@ -12,24 +12,6 @@
         }
       {% endif %}
 
-      {# Title #}
-
-      .card__title {
-        {{ module.styles.title.text.font.css }}
-        {% if module.styles.title.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.title.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      {# Content #}
-
-      .card__content {
-        {{ module.styles.content.text.font.css }}
-        {% if module.styles.content.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.content.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
       {# Card #}
 
       .card {

--- a/src/modules/card.module/module.html
+++ b/src/modules/card.module/module.html
@@ -69,14 +69,11 @@
          {% set loadingAttr = card.image.loading != 'disabled' ? 'loading="{{ card.image.loading }}"' : '' %}
         <img class="card__image" src="{{ card.image.src }}" alt="{{ card.image.alt }}" {{ loadingAttr }} {{ sizeAttrs }}>
       {% endif %}
-      <div class="card__text">
-        {% if card.title %}
-          <{{ card.title_heading_type }} class="card__title">{{ card.title }}</{{ card.title_heading_type }}>
-        {% endif %}
-        {% if card.text %}
-          <p class="card__content">{{ card.text }}</p>
-        {% endif %}
-      </div>
+      {% if card.text %}
+        <div class="card__text">
+          {{ card.text }}
+        </div>
+      {% endif %}
     </section>
   {% endfor %}
 

--- a/src/modules/pricing-card.module/fields.json
+++ b/src/modules/pricing-card.module/fields.json
@@ -3,35 +3,28 @@
     "label": "Product tier",
     "name": "tier",
     "id": "tier",
-    "type": "text",
-    "default": "Free"
-  },
-  {
-    "label": "Product tier heading type",
-    "name": "tier_heading_type",
-    "type": "choice",
-    "choices": [
-      ["h1", "Heading 1"],
-      ["h2", "Heading 2"],
-      ["h3", "Heading 3"],
-      ["h4", "Heading 4"],
-      ["h5", "Heading 5"],
-      ["h6", "Heading 6"]
+    "type": "richtext",
+    "enabled_features": [
+      "alignment",
+      "block",
+      "font_family",
+      "font_size",
+      "standard_emphasis"
     ],
-    "display": "select",
-    "required": true,
-    "visibility": {
-      "controlling_field": "tier",
-      "controlling_value_regex": "",
-      "operator": "NOT_EQUAL"
-    },
-    "default": "h2"
+    "default": "<h2>Free</h2>"
   },
   {
     "label": "Product description",
     "name": "description",
-    "type": "text",
-    "default": "For teams that need additional security, control, and support."
+    "type": "richtext",
+    "enabled_features": [
+      "alignment",
+      "block",
+      "font_family",
+      "font_size",
+      "standard_emphasis"
+    ],
+    "default": "<p>For teams that need additional security, control, and support.</p>"
   },
   {
     "label": "Features list icon",
@@ -99,70 +92,6 @@
     "type": "group",
     "tab": "STYLE",
     "children": [
-      {
-        "label": "Product tier",
-        "name": "product_tier",
-        "type": "group",
-        "children": [
-          {
-            "label": "Text",
-            "name": "text",
-            "type": "group",
-            "children": [
-              {
-                "label": "Font",
-                "name": "font",
-                "type": "font"
-              }
-            ]
-          },
-          {
-            "label": "Alignment",
-            "name": "alignment",
-            "type": "group",
-            "children": [
-              {
-                "label": "Alignment",
-                "name": "alignment",
-                "type": "alignment",
-                "alignment_direction": "HORIZONTAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "label": "Product description",
-        "name": "product_description",
-        "type": "group",
-        "children": [
-          {
-            "label": "Text",
-            "name": "text",
-            "type": "group",
-            "children": [
-              {
-                "label": "Font",
-                "name": "font",
-                "type": "font"
-              }
-            ]
-          },
-          {
-            "label": "Alignment",
-            "name": "alignment",
-            "type": "group",
-            "children": [
-              {
-                "label": "Alignment",
-                "name": "alignment",
-                "type": "alignment",
-                "alignment_direction": "HORIZONTAL"
-              }
-            ]
-          }
-        ]
-      },
       {
         "label": "Features",
         "name": "features",

--- a/src/modules/pricing-card.module/module.html
+++ b/src/modules/pricing-card.module/module.html
@@ -4,24 +4,6 @@
   <style>
     {% scope_css %}
 
-      {# Product tier #}
-
-      .card__heading {
-        {{ module.styles.product_tier.text.font.css }}
-        {% if module.styles.product_tier.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.product_tier.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
-      {# Product description #}
-
-      .card__subtitle {
-        {{ module.styles.product_description.text.font.css }}
-        {% if module.styles.product_description.alignment.alignment.horizontal_align %}
-          text-align: {{ module.styles.product_description.alignment.alignment.horizontal_align }};
-        {% endif %}
-      }
-
       {# Features #}
 
       .card__hr {
@@ -128,10 +110,10 @@
   {% if module.tier and module.description %}
     <div class="card__header">
       {% if module.tier %}
-        <{{ module.tier_heading_type }} class="card__heading">{{ module.tier }}</{{ module.tier_heading_type }}>
+        {{ module.tier }}
       {% endif %}
       {% if module.description %}
-        <p class="card__subtitle"> {{ module.description }}</p>
+        {{ module.description }}
       {% endif %}
     </div>
   {% endif %}

--- a/src/sections/cards.html
+++ b/src/sections/cards.html
@@ -27,9 +27,7 @@
               'size_type': 'auto_custom_max',
               'src': context.card_one_image || get_asset_url('../images/phone.png')
             },
-            'text': context.card_one_content || '(887) 929-0687',
-            'title': context.card_one_title || '',
-            'title_heading_type': context.card_one_title_heading_type || 'h2'
+            'text': context.card_one_content || '<p>(887) 929-0687</p>',
           },
           {
             'image': {
@@ -40,9 +38,7 @@
               'size_type': 'auto_custom_max',
               'src': context.card_two_image || get_asset_url('../images/email.png')
             },
-            'text': context.card_two_content || 'contact@business.com',
-            'title': context.card_two_title || '',
-            'title_heading_type': context.card_two_title_heading_type || 'h2'
+            'text': context.card_two_content || '<p>contact@business.com</p>',
           },
           {
             'image': {
@@ -53,9 +49,7 @@
               'size_type': 'auto_custom_max',
               'src': context.card_three_image || get_asset_url('../images/location.png')
             },
-            'text': context.card_three_content || '2 Canal Park, Cambridge, MA 02141',
-            'title': context.card_three_title || '',
-            'title_heading_type': context.card_three_title_heading_type || 'h2'
+            'text': context.card_three_content || '<p>2 Canal Park, Cambridge, MA 02141</p>',
           }
         ]
       %}

--- a/src/sections/pricing.html
+++ b/src/sections/pricing.html
@@ -18,7 +18,7 @@
       {% dnd_module
         path='../modules/pricing-card',
         button_text={{ context.card_one_button_text || 'Buy starter' }},
-        description={{ context.card_one_description ||'For individuals or team just getting started with sales.' }},
+        description={{ context.card_one_description ||'<p>For individuals or team just getting started with sales.</p>' }},
         features=[
           'Ad management',
           'Live chat',
@@ -32,8 +32,7 @@
         ],
         offset=0,
         price={{ context.card_one_price || '$0' }},
-        tier={{ context.card_one_tier || 'Starter' }},
-        tier_heading_type={{ context.card_tier_heading_type || 'h2' }},
+        tier={{ context.card_one_tier || '<h2>Starter</h2>' }},
         timeframe={{ context.card_one_timeframe || '/mo' }},
         width=4
       %}
@@ -41,7 +40,7 @@
       {% dnd_module
         path='../modules/pricing-card',
         button_text={{ context.card_two_button_text || 'Buy professional' }},
-        description={{ context.card_two_description || 'For teams that need to create sales plans with confidence.' }},
+        description={{ context.card_two_description || '<p>For teams that need to create sales plans with confidence.</p>' }},
         features=[
           'Marketing automation',
           'Smart content',
@@ -55,8 +54,7 @@
         ],
         offset=4,
         price={{ context.card_two_price || '$1200' }},
-        tier={{ context.card_two_tier || 'Professional' }},
-        tier_heading_type={{ context.card_two_tier_heading_type || 'h2' }},
+        tier={{ context.card_two_tier || '<h2>Professional</h2>' }},
         timeframe={{ context.card_two_timeframe || '/mo' }},
         width=4
       %}
@@ -64,7 +62,7 @@
       {% dnd_module
         path='../modules/pricing-card',
         button_text={{ context.card_three_button_text ||'Buy enterprise' }},
-        description={{ context.card_three_description ||'For teams that need additional security, control, and support.' }},
+        description={{ context.card_three_description ||'<p>For teams that need additional security, control, and support.</p>' }},
         features=[
           'Content partitioning',
           'Hierarchical teams',
@@ -78,8 +76,7 @@
         ],
         offset=8,
         price={{ context.card_three_price ||'$3200' }},
-        tier={{ context.card_three_tier ||'Enterprise' }},
-        tier_heading_type={{ context.card_three_tier_heading_type ||'h2' }},
+        tier={{ context.card_three_tier ||'<h2>Enterprise</h2>' }},
         timeframe={{ context.card_three_timeframe ||'/mo' }},
         width=4
       %}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This changes moves some text field over to rich text fields to allow for more flexibility on the content creators end and uses the rich text field config options to demonstrate how you can set some boundaries in terms of what someone can edit within those rich text fields. This also follows the same pattern in Growth in that for rich text fields, we don't have style fields that target them and instead we just offer the basic styling options via the rich text editor (e.g. alignment, font size, font family, etc.). We found that this pattern made more sense to users during user testing. 

**Relevant links**

Fixes #398 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
