### PR TITLE
theme-overrides.css changed to use the correct variable for form textarea

### DIFF
--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -295,7 +295,7 @@ form input[type=number],
 form input[type=file],
 form select,
 form textarea {
-  {{ form_input_border }}
+  {{ form_field_border }}
   background-color: {{ form_field_bg_color }};
   color: {{ form_field_font_color }};
   border-radius: {{ form_field_corner_radius }};


### PR DESCRIPTION

**Types of change**

- [x] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

CSS for form textarea no longer uses nonexistent variable.

**Relevant links**

GitHub issue: #405

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.

**People to notify**
@jasonnrosa 
