### PR TITLE
Resolving design manager warnings from theme-overrides.css

### DIFF
--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -256,7 +256,7 @@ button:active,
 .button:active {
   {{ button_font.style }};
   background-color: rgba({{ color_variant(theme.buttons.background.color.color, 40)|convert_rgb }}, {{ theme.buttons.background.color.opacity / 100 }});
-  border-color: {{ color_variant(theme.buttons.border_color.color, 40) }};
+  border-color: {{ color_variant(theme.buttons.border.border.top.color, 40) }};
 }
 
 {###########################################################################}
@@ -363,7 +363,7 @@ form .hs-button:focus {
 form input[type=submit]:active,
 form .hs-button:active {
   background-color: rgba({{ color_variant(theme.buttons.background.color.color, 40)|convert_rgb }}, {{ theme.buttons.background.color.opacity / 100 }});
-  border-color: {{ color_variant(theme.buttons.border_color.color, 40) }};
+  border-color: {{ color_variant(theme.buttons.border.border.top.color, 40) }};
 }
 
 {###########################################################################}
@@ -383,7 +383,6 @@ td,
 th {
   {{ table_border }}
   {{ table_cell_spacing }}
-  border-color: {{ table_border_color }};
   color: {{ table_font_color }};
 }
 
@@ -470,7 +469,7 @@ tfoot td {
 }
 
 .header__language-switcher .lang_list_class:before {
-  border-bottom-color: {{ theme.header.drop_downs.border.border.top.color }};
+  border-bottom-color: {{ theme.header.menu.drop_downs.border.border.top.color }};
 }
 
 .menu__submenu .menu__link:hover,


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

There were a few warnings in the `theme-overrides.css` file that we found via the design manager. There were three incorrect references to field paths and one field reference that was outdated/no longer needed. 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
