### PR TITLE
Preventing textarea field from being resized horizontally

### DIFF
--- a/src/css/elements/_forms.css
+++ b/src/css/elements/_forms.css
@@ -34,6 +34,10 @@ form textarea {
   width: 100%;
 }
 
+form textarea {
+  resize: vertical;
+}
+
 form fieldset {
   max-width: 100% !important;
 }


### PR DESCRIPTION
**Types of change**

- [X] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

The textarea field could previously be resized horizontally which didn't create a good user experience and could lead to responsiveness issues. I've set `resize: vertical;` on the textarea field to combat this.

**Relevant links**

Example video after fix: https://www.loom.com/share/dad765647762421a82f55830dbc36f0e
Fixes #426 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
