### PR TITLE
Removing old teams from notifications

### DIFF
--- a/hubspot.deploy/cms-theme-boilerplate.yaml
+++ b/hubspot.deploy/cms-theme-boilerplate.yaml
@@ -1,8 +1,5 @@
 team: hs-content-assets
 
-contributors:
-  - hs-cms-assets-io@hubinfra.com
-
 type: static_deployed_pointer
 
 description: Boilerplate Theme
@@ -10,15 +7,6 @@ description: Boilerplate Theme
 artifactBuildMetadata:
   repository: cms-theme-boilerplate
   module: cms-theme-boilerplate
-
-slack:
-  - channelName: "#cms-assets-io-notif"
-    all:
-      preDeploy: MUTE
-      success: MUTE
-      failure: NOTIFY
-      notifyForBlockerEvents: MUTE
-      deployedNotRun: MUTE
 
 qaAutoDeployedBranches:
 - main


### PR DESCRIPTION
⚠️ Please note this is an internal change that doesn't impact the actual boilerplate theme

**Description:** 
Removing teams from notifications in `cms-deploy.yaml`