### PR TITLE
Update landing page template with block to remove global footer

### DIFF
--- a/src/templates/landing-page.html
+++ b/src/templates/landing-page.html
@@ -35,7 +35,7 @@
   %}
 
 {% end_dnd_area %}
+{% endblock body %}
 
 {% block footer %}
 {% endblock footer %}
-{% endblock body %}


### PR DESCRIPTION
**Types of change**

- [x] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds a HubL footer block to the landing page template to remove footer navigation from landing pages.

**Relevant links**

Example page:
GitHub issue:
Addresses issue #118 

**Checklist**

- [x ] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x ] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ x] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
