### PR TITLE
Updating layout.css to use flex vs. float

### DIFF
--- a/src/css/objects/_layout.css
+++ b/src/css/objects/_layout.css
@@ -1,211 +1,33 @@
-/* Responsive grid */
+/* CSS variables */
+
+:root {
+  --gap: 2.127659574%;
+}
+
+/* Mobile layout */
 
 .row-fluid {
-  width: 100%;
-}
-
-.row-fluid:before, .row-fluid:after {
-  display: table;
-  content: '';
-}
-
-.row-fluid:after {
-  clear: both;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%:
 }
 
 .row-fluid [class*='span'] {
-  display: block;
-  float: left;
-  width: 100%;
   min-height: 1px;
-  margin-left: 2.127659574%;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -ms-box-sizing: border-box;
-  box-sizing: border-box;
+  width: 100%;
 }
 
-.row-fluid [class*='span']:first-child {
-  margin-left: 0;
-}
+/* Desktop layout */
 
-.row-fluid .span12 {
-  width: 99.99999998999999%;
-}
-
-.row-fluid .span11 {
-  width: 91.489361693%;
-}
-
-.row-fluid .span10 {
-  width: 82.97872339599999%;
-}
-
-.row-fluid .span9 {
-  width: 74.468085099%;
-}
-
-.row-fluid .span8 {
-  width: 65.95744680199999%;
-}
-
-.row-fluid .span7 {
-  width: 57.446808505%;
-}
-
-.row-fluid .span6 {
-  width: 48.93617020799999%;
-}
-
-.row-fluid .span5 {
-  width: 40.425531911%;
-}
-
-.row-fluid .span4 {
-  width: 31.914893614%;
-}
-
-.row-fluid .span3 {
-  width: 23.404255317%;
-}
-
-.row-fluid .span2 {
-  width: 14.89361702%;
-}
-
-.row-fluid .span1 {
-  width: 6.382978723%;
-}
-
-.container-fluid:before, .container-fluid:after {
-  display: table;
-  content: '';
-}
-
-.container-fluid:after {
-  clear: both;
-}
-
-@media (max-width: 767px) {
+@media (min-width: 768px) {
   .row-fluid {
-    width: 100%;
+    flex-wrap: nowrap;
+    column-gap: var(--gap);
+    justify-content: space-between;
   }
 
   .row-fluid [class*='span'] {
-    display: block;
-    float: none;
-    width: auto;
-    margin-left: 0;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1139px) {
-  .row-fluid {
-    width: 100%;
-  }
-
-  .row-fluid:before, .row-fluid:after {
-    display: table;
-    content: '';
-  }
-
-  .row-fluid:after {
-    clear: both;
-  }
-
-  .row-fluid [class*='span'] {
-    display: block;
-    float: left;
-    width: 100%;
-    min-height: 1px;
-    margin-left: 2.762430939%;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -ms-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-
-  .row-fluid [class*='span']:first-child {
-    margin-left: 0;
-  }
-
-  .row-fluid .span12 {
-    width: 99.999999993%;
-  }
-
-  .row-fluid .span11 {
-    width: 91.436464082%;
-  }
-
-  .row-fluid .span10 {
-    width: 82.87292817100001%;
-  }
-
-  .row-fluid .span9 {
-    width: 74.30939226%;
-  }
-
-  .row-fluid .span8 {
-    width: 65.74585634900001%;
-  }
-
-  .row-fluid .span7 {
-    width: 57.182320438000005%;
-  }
-
-  .row-fluid .span6 {
-    width: 48.618784527%;
-  }
-
-  .row-fluid .span5 {
-    width: 40.055248616%;
-  }
-
-  .row-fluid .span4 {
-    width: 31.491712705%;
-  }
-
-  .row-fluid .span3 {
-    width: 22.928176794%;
-  }
-
-  .row-fluid .span2 {
-    width: 14.364640883%;
-  }
-
-  .row-fluid .span1 {
-    width: 5.801104972%;
-  }
-}
-
-@media (min-width: 1280px) {
-  .row-fluid {
-    width: 100%;
-  }
-
-  .row-fluid:before, .row-fluid:after {
-    display: table;
-    content: '';
-  }
-
-  .row-fluid:after {
-    clear: both;
-  }
-
-  .row-fluid [class*='span'] {
-    display: block;
-    float: left;
-    width: 100%;
-    min-height: 1px;
-    margin-left: 2.564102564%;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -ms-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-
-  .row-fluid [class*='span']:first-child {
-    margin-left: 0;
+    flex: 1;
   }
 
   .row-fluid .span12 {
@@ -213,126 +35,46 @@
   }
 
   .row-fluid .span11 {
-    width: 91.45299145300001%;
+    width: calc(91.66% - var(--gap));
   }
 
   .row-fluid .span10 {
-    width: 82.905982906%;
+    width: calc(83.33% - var(--gap));
   }
 
   .row-fluid .span9 {
-    width: 74.358974359%;
+    width: calc(75% - var(--gap));
   }
 
   .row-fluid .span8 {
-    width: 65.81196581200001%;
+    width: calc(66.66% - var(--gap));
   }
 
   .row-fluid .span7 {
-    width: 57.264957265%;
+    width: calc(58.33% - var(--gap));
   }
 
   .row-fluid .span6 {
-    width: 48.717948718%;
+    width: calc(50% - var(--gap));
   }
 
   .row-fluid .span5 {
-    width: 40.170940171000005%;
+    width: calc(41.66% - var(--gap));
   }
 
   .row-fluid .span4 {
-    width: 31.623931624%;
+    width: calc(33.33% - var(--gap));
   }
 
   .row-fluid .span3 {
-    width: 23.076923077%;
+    width: calc(25% - var(--gap));
   }
 
   .row-fluid .span2 {
-    width: 14.529914530000001%;
+    width: calc(16.66% - var(--gap));
   }
 
   .row-fluid .span1 {
-    width: 5.982905983%;
-  }
-}
-
-/* Clearfix */
-
-.clearfix:before, .clearfix:after {
-  display: table;
-  content: '';
-}
-
-.clearfix:after {
-  clear: both;
-}
-
-/* Visibilty classes */
-
-.hide {
-  display: none;
-}
-
-.show {
-  display: block;
-}
-
-.invisible {
-  visibility: hidden;
-}
-
-.hidden {
-  display: none;
-  visibility: hidden;
-}
-
-/* Responsive visibilty classes */
-
-.visible-phone {
-  display: none !important;
-}
-
-.visible-tablet {
-  display: none !important;
-}
-
-.hidden-desktop {
-  display: none !important;
-}
-
-@media (max-width: 767px) {
-  .visible-phone {
-    display: inherit !important;
-  }
-
-  .hidden-phone {
-    display: none !important;
-  }
-
-  .hidden-desktop {
-    display: inherit !important;
-  }
-
-  .visible-desktop {
-    display: none !important;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 1139px) {
-  .visible-tablet {
-    display: inherit !important;
-  }
-
-  .hidden-tablet {
-    display: none !important;
-  }
-
-  .hidden-desktop {
-    display: inherit !important;
-  }
-
-  .visible-desktop {
-    display: none !important;
+    width: calc(8.33% - var(--gap));
   }
 }

--- a/src/css/objects/_layout.css
+++ b/src/css/objects/_layout.css
@@ -9,7 +9,7 @@
 .row-fluid {
   display: flex;
   flex-wrap: wrap;
-  width: 100%:
+  width: 100%;
 }
 
 .row-fluid [class*='span'] {

--- a/src/css/objects/_layout.css
+++ b/src/css/objects/_layout.css
@@ -22,16 +22,7 @@
 @media (min-width: 768px) {
   .row-fluid {
     flex-wrap: nowrap;
-    column-gap: var(--gap);
     justify-content: space-between;
-  }
-
-  .row-fluid [class*='span'] {
-    flex: 1;
-  }
-
-  .row-fluid .span12 {
-    width: 100%;
   }
 
   .row-fluid .span11 {


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

This change tackles the following: 
- Updates `layout.css` file to use a flex grid vs. float for the grid
- Uses mobile first approach for media queries
- Uses CSS var for easily adjustable gap so it is easy to adjust
- Removes some extra helper classes that weren't being utilized in boilerplate

This approach takes a bit from the current Bootstrap 5 grid, takes inspiration from some work @stefenphelps had done [here](https://stefenphelps.com/blog/custom-grid-gutters-on-hubspot/) / work @anthmatic had done previously, and uses some of the existing concepts in `layout.css`. 

Notes/questions: 
- When `flex-wrap: wrap;` was set for `row-fluid` I noticed that `gap` wasn't factored into column width (similar to how `padding` would be with `box-sizing: border-box;`) therefore I used `calc` to calculate the column width minus the gap. Technically this doesn't appear to be needed in most browsers when using `flex-wrap: nowrap;` but I just wanted to fully make sure all rows calculated to a 100% width. Open to suggestions on this approach!
- I wanted to get this layout as close as I could to the existing layout without a major change. The main goal being that it would be easy to update existing projects without much difference (generally speaking there should be no major discernible difference between the existing boilerplate and this branch). That is why I'm using a rather particular gap value. Another note is that in the original `layout.css` there are different gaps depending on screen width (e.g. margins get larger at larger screen widths). I think given we're using percentage widths for the gap I'm not as inclined to increase the gap at specific screen widths given it would essentially double or triple the CSS to get a perfect match but as of right now it should be extremely close. 

I've tested across major browsers and everything looked nearly identical to the existing layout but would certainly appreciate if anyone wanted to pull this branch down and also test out to see if I missed anything. 

**Relevant links**

Fixes #319 

**Checklist**

- [X] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [X] I have thoroughly tested my change.

**People to notify**
CC: @TheWebTech and @ajlaporte
