### PR TITLE
Add recommendation for using hubspot vs code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"hubspot.hubl"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}


### PR DESCRIPTION
**Types of change**

- [x] New feature (change which adds new functionality)

**Description**

Upon opening the repo locally for the first time VS Code users will be recommended to install the HubSpot VS Code Extension. Making it easier for users to become aware of it. Additionally a user can trigger viewing the recommended extensions intentionally by using the `Extensions: Show Recommended Extensions`. The recommendation should not appear for anyone who already has the extension installed.


**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.

**People to notify**
@jasonnrosa
