### PR TITLE
Updating email referenced in author information

### DIFF
--- a/src/theme.json
+++ b/src/theme.json
@@ -1,9 +1,9 @@
 {
   "label": "CMS theme boilerplate",
   "author": {
-		"name": "HubSpot",
-		"email": "content-assets@hubspot.com",
-		"url": "https://www.hubspot.com/"
+    "name": "HubSpot",
+    "email": "hs-content-assets@hubspot.com",
+    "url": "https://www.hubspot.com/"
 	},
   "documentation_url": "https://developers.hubspot.com/docs/cms/building-blocks/themes/hubspot-cms-boilerplate",
   "example_url": "https://boilerplate.hubspotcms.com",


### PR DESCRIPTION
Updating author email used in `theme.json` as we are moving away from the previous email that was listed there