### PR TITLE
Specify buildpack name not location

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,8 +1,5 @@
 buildpack:
-  host: git.hubteam.com
-  organization: HubSpot
-  repository: CMSAssetBuildpack
-  branch: main
+  name: CMSAssetBuildpack
 
 before:
   - description: Copies assets in the src directory to an @hubspot/boilerplate directory


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

We now reference buildpacks by name rather than a github location

**Relevant links**

Example page:
GitHub issue:

**Checklist**

- [ ] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [ ] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
