### PR TITLE
update: logo lazy loading attribute in templates

### DIFF
--- a/src/templates/partials/header-no-navigation.html
+++ b/src/templates/partials/header-no-navigation.html
@@ -19,7 +19,12 @@
     {# Logo #}
 
     <div class="header__logo">
-      {% module "site_logo" path="@hubspot/logo" %}
+      {% module "site_logo"
+        path="@hubspot/logo"
+        img={
+          "loading": "eager"
+        }
+      %}
     </div>
 
   </div>

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -23,7 +23,12 @@
     {# Header logo column #}
 
     <div class="header__logo header__logo--main">
-      {% module "site_logo" path="@hubspot/logo" %}
+      {% module "site_logo"
+        path="@hubspot/logo"
+        img={
+          "loading": "eager"
+        }
+      %}
     </div>
 
     {# Header navigation column #}


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Update instances of @hubspot/logo in templates to use appropriate lazy_loading. Header instances are set to "eager"

<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
