### PR TITLE
Remove alternate_names

### DIFF
--- a/src/fields.json
+++ b/src/fields.json
@@ -8,7 +8,6 @@
         "label": "Primary",
         "name": "primary",
         "type": "color",
-        "alternate_names": ["primary_color"],
         "visibility": {
           "hidden_subfields": {
             "opacity": true
@@ -27,7 +26,6 @@
         "label": "Secondary",
         "name": "secondary",
         "type": "color",
-        "alternate_names": ["secondary_color"],
         "visibility": {
           "hidden_subfields": {
             "opacity": true
@@ -53,7 +51,6 @@
         "label": "Primary",
         "name": "primary",
         "type": "font",
-        "alternate_names": ["body_font"],
         "visibility": {
           "hidden_subfields": {
             "size": true,
@@ -75,7 +72,6 @@
         "label": "Secondary",
         "name": "secondary",
         "type": "font",
-        "alternate_names": ["heading_font"],
         "visibility": {
           "hidden_subfields": {
             "size": true,


### PR DESCRIPTION
**Types of change**

- Revert

**Description**

`alternate_names` were added to the fields.json for the theme, but there [are some discussions](https://hubspot.slack.com/archives/C04CWRTJZSB/p1679499758790889) about changing how these should work. We may reincorporate these in the future but for now we'll remove them.