### PR TITLE
Adding hs-button class to theme button styles

### DIFF
--- a/src/css/elements/_buttons.css
+++ b/src/css/elements/_buttons.css
@@ -1,5 +1,6 @@
 button,
-.button {
+.button,
+.hs-button {
   cursor: pointer;
   display: inline-block;
   text-align: center;
@@ -8,7 +9,8 @@ button,
 }
 
 button:disabled,
-.button:disabled {
+.button:disabled,
+.hs-button:disabled {
   background-color: #D0D0D0;
   border-color: #D0D0D0;
   color: #E6E6E6;

--- a/src/css/theme-overrides.css
+++ b/src/css/theme-overrides.css
@@ -266,6 +266,7 @@ blockquote {
 
 button,
 .button,
+.hs-button,
 .hs-blog-post-listing__post-button {
   {{ button_border }}
   {{ button_spacing }}
@@ -281,6 +282,8 @@ button:hover,
 button:focus,
 .button:hover,
 .button:focus,
+.hs-button:hover,
+.hs-button:focus,
 .hs-blog-post-listing__post-button:hover,
 .hs-blog-post-listing__post-button:focus {
   {{ button_border_hover }};
@@ -291,6 +294,7 @@ button:focus,
 
 button:active,
 .button:active,
+.hs-button:active,
 .hs-blog-post-listing__post-button:active {
   {{ button_font.style }};
   background-color: rgba({{ color_variant(theme.buttons.background.color.color, 40)|convert_rgb }}, {{ theme.buttons.background.color.opacity / 100 }});


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [X] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Per the issue linked below, theme styles applied to theme settings wouldn't apply to the default button module which can be confusing for a user. We have some plans to make this better long term in other ways (e.g. in this case I think improving the default button and not having a theme specific version would help/being able to hide the default in favor of a theme module; and being able to reliably inherit from theme settings from default modules will also help) but in the interim this should help ensure that theme settings apply to the default and theme module in this case. 

**Relevant links**

Example page: [Example page with default and theme module stacked on top of each other](https://jrosa-102019231.hs-sitesqa.com/testing-button)
GitHub issue: fixes #463 

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.
