### PR TITLE
Update/search results template query var

### DIFF
--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -12,17 +12,37 @@
 {% block body %}
 <section class="content-wrapper">
   <div class="systems-page systems-page--search-results">
-    {% module_block module "search_results_content"
-      label="Search results heading",
-      path="@hubspot/rich_text"
-    %}
-      {% module_attribute "html" %}
-        <h1>Results for "{{ request.query_dict.term|escape }}"</h1>
-      {% end_module_attribute %}
-    {% end_module_block %}
-    {% module "search_results"
-      path="@hubspot/search_results"
-    %}
+     {%- if (get_asset_version("@hubspot/search_results") == 0) -%}
+      {% if request.query_dict.term %}
+        {% set search_query = request.query_dict.term %}
+      {% elif request.query_dict.q %}
+        {# v3 search api support #}
+        {% set search_query = request.query_dict.q %}
+      {% endif %}
+
+      {% module_block module 'search_results_content'
+        label='Search results heading',
+        path='@hubspot/rich_text'
+      %}
+        {% module_attribute 'html' %}
+          <h1>Results for &ldquo;{{ search_query|escape }}&rdquo;</h1>
+        {% end_module_attribute %}
+      {% end_module_block %}
+
+        {% module "search_results"
+          path="@hubspot/search_results"
+        %}
+
+      {%- else -%}
+
+        {% module "search_results"
+          path="@hubspot/search_results",
+          title={
+            "show_title": "true"
+          }
+        %}
+
+    {%- endif -%}
   </div>
 </section>
 {% endblock body %}

--- a/src/templates/system/search-results.html
+++ b/src/templates/system/search-results.html
@@ -12,7 +12,7 @@
 {% block body %}
 <section class="content-wrapper">
   <div class="systems-page systems-page--search-results">
-     {%- if (get_asset_version("@hubspot/search_results") == 0) -%}
+    {%- if (get_asset_version("@hubspot/search_results") == 0) -%}
       {% if request.query_dict.term %}
         {% set search_query = request.query_dict.term %}
       {% elif request.query_dict.q %}


### PR DESCRIPTION
**Types of change**

- [ x ] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds a version check for the search results module as well as support for v3 api. Search results used to use the `?term=` but now can use `?q=` which initially broke some of the titles on the search results page. This fixes that bug.

<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
