### PR TITLE
update: connect h5 to inherit from secondary font color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cms-theme-boilerplate",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Boilerplate project for building websites on the HubSpot CMS",
   "repository": {
     "type": "git",

--- a/src/fields.json
+++ b/src/fields.json
@@ -301,6 +301,7 @@
             "type": "font",
             "inherited_value": {
               "property_value_paths": {
+                "color": "theme.global_fonts.secondary.color",
                 "fallback": "theme.global_fonts.secondary.fallback",
                 "font": "theme.global_fonts.secondary.font",
                 "font_set": "theme.global_fonts.secondary.font_set"


### PR DESCRIPTION
**Types of change**

- [x] Bug fix (change which fixes an issue)
- [ ] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Seems like h5 inheritance from `theme.global_fonts.secondary.color` might have been forgotten. This PR links it back up. 

More [details](https://hubspot.slack.com/archives/C0225PER3TM/p1686948320414699). 

![2023-06-20 13 10 44](https://github.com/HubSpot/cms-theme-boilerplate/assets/39243773/7947e089-376a-42fc-a921-3c93aff04ef9)


**Relevant links**

Example page:
GitHub issue:

**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
