### PR TITLE
update: add cta link type to button module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/cms-theme-boilerplate",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Boilerplate project for building websites on the HubSpot CMS",
   "repository": {
     "type": "git",

--- a/src/modules/button.module/fields.json
+++ b/src/modules/button.module/fields.json
@@ -3,7 +3,13 @@
     "label": "Button link",
     "name": "link",
     "type": "link",
-    "supported_types": ["EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS"],
+    "supported_types": [
+      "EXTERNAL",
+      "CONTENT",
+      "FILE",
+      "EMAIL_ADDRESS",
+      "CALL_TO_ACTION"
+    ],
     "default": {
       "url": {
         "href": "",
@@ -56,9 +62,9 @@
         "type": "group",
         "children": [
           {
-            "label" : "Border",
-            "name" : "border",
-            "type" : "border"
+            "label": "Border",
+            "name": "border",
+            "type": "border"
           }
         ]
       },


### PR DESCRIPTION
**Types of change**

- [ ] Bug fix (change which fixes an issue)
- [x] Enhancement (change which improves upon an existing feature)
- [ ] New feature (change which adds new functionality)

**Description**

Adds the CTA link type to the button module. This allows users to link to pop-up ctas if they have them enabled on their portal. 

**Relevant links**
![Screenshot 2023-07-17 at 1 34 21 PM](https://github.com/HubSpot/cms-theme-boilerplate/assets/39243773/45546897-8d74-40c8-943b-0504c0983610)


**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
