### PR TITLE
Allow <a> tags to have underline

### DIFF
--- a/src/fields.json
+++ b/src/fields.json
@@ -421,7 +421,10 @@
               }
             },
             "default": {
-              "color": "#0270E0"
+              "color": "#0270E0",
+              "styles": {
+                "text-decoration": "underline"
+              }
             }
           }
         ]

--- a/src/fields.json
+++ b/src/fields.json
@@ -421,10 +421,7 @@
               }
             },
             "default": {
-              "color": "#0270E0",
-              "styles": {
-                "text-decoration": "none"
-              }
+              "color": "#0270E0"
             }
           }
         ]


### PR DESCRIPTION
**Types of change**

- [x] Bug fix (change which fixes an issue)

**Description**

We reviewed all of the boilerplate templates as part of an accessibility audit, and found that `<a>` tags failed the ["Links must be distinguishable without relying on color"](https://dequeuniversity.com/rules/axe/4.8/link-in-text-block?application=AxeChrome) rule. Allowing `<a>` tags to have an underline satisfies this requirement, so we're removing the field default which removes them. 
 
**Checklist**

- [x] I have read the [CONTRIBUTING](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the [style guide requirements](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md).
- [x] I have thoroughly tested my change.

**People to notify**
<!-- If your change requires an update to our documentation on https://designers.hubspot.com/docs (for example, if a file in the repository is renamed or moved) please tag: @TheWebTech and @ajlaporte -->
